### PR TITLE
Prove chain and state machine invariants (PROP-9,14,17,21,26,30,33,39)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,15 @@ TypesExternal_Template.lean
 node_modules/
 dist/
 
+# Local / generated
+.vscode/
+data/
+functions.json
+signal-spqr-hax/
+issues/
+docs/*.pdf
+sorry-manifest.txt
+docs/STATE_INVARIANT_PROOFS.md
+
 # MacOS
 .DS_Store

--- a/Spqr/Specs/Chain/AddEpoch.lean
+++ b/Spqr/Specs/Chain/AddEpoch.lean
@@ -1,0 +1,94 @@
+/-
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Spqr.Specs.External
+
+/-! # PROP-9: Epoch Monotonicity
+
+Specification and proof for `chain.Chain.add_epoch` (PROP-9 from
+`docs/mlkembraid_spec/1_scka_interface.md`).
+
+Given precondition `es.epoch = c.current_epoch + 1 ∧ c.current_epoch < U64.max`,
+the post-state satisfies `c'.current_epoch = es.epoch`.
+
+`Chain::add_epoch` returns `()` and mutates `self` in Rust
+(`chain.rs:350`). The Aeneas extraction models this as a state-passing
+function returning the new `Chain`. The Lean postcondition is over the
+*post-state*, not over a `result` field.
+
+**Source**: spqr/src/chain.rs (lines 350:4-369:5)
+-/
+
+open Aeneas Aeneas.Std Result
+
+namespace spqr
+
+/-! ## Helper specs for intermediate defined functions -/
+
+/-- `Direction.switch` always succeeds: A2B ↦ B2A and B2A ↦ A2B. -/
+@[step]
+theorem Direction.switch_spec (d : proto.pq_ratchet.Direction) :
+    Direction.switch d ⦃ _ => True ⦄ := by
+  unfold Direction.switch
+  match d with
+  | .A2B => simp only [WP.spec, WP.theta, WP.wp_return]
+  | .B2A => simp only [WP.spec, WP.theta, WP.wp_return]
+
+/-- `KeyHistory.KEY_SIZE` evaluates to 36. -/
+@[step]
+theorem chain.KeyHistory.KEY_SIZE_spec :
+    chain.KeyHistory.KEY_SIZE ⦃ i => i.val = 36 ⦄ := by
+  unfold chain.KeyHistory.KEY_SIZE
+  step*
+
+/-- `KeyHistory.new` always succeeds. -/
+@[step]
+theorem chain.KeyHistory.new_spec :
+    chain.KeyHistory.new ⦃ _ => True ⦄ := by
+  unfold chain.KeyHistory.new
+  step*
+
+/-- `ChainEpochDirection.new` always succeeds for any input slice. -/
+@[step]
+theorem chain.ChainEpochDirection.new_spec (k : Slice Std.U8) :
+    chain.ChainEpochDirection.new k ⦃ _ => True ⦄ := by
+  unfold chain.ChainEpochDirection.new
+  step*
+
+/-- `Chain.ced_for_direction` always succeeds when the generator
+slice has at least 96 bytes (which it always does in `add_epoch`
+since `genr8r = Array.repeat 96 0`). -/
+@[step]
+theorem chain.Chain.ced_for_direction_spec
+  (genr8r : Slice Std.U8) (dir : proto.pq_ratchet.Direction)
+  (hlen : genr8r.length ≥ 96) :
+    chain.Chain.ced_for_direction genr8r dir ⦃ _ => True ⦄ := by
+  unfold chain.Chain.ced_for_direction
+  match dir with
+  | .A2B => simp only []; step*
+  | .B2A => simp only []; step*
+
+/-! ## PROP-9: Main theorem -/
+
+/-- **PROP-9 — Epoch Monotonicity.**
+
+If `chain.Chain.add_epoch` succeeds, then the post-state's
+`current_epoch` equals `epoch_secret.epoch`.
+
+The preconditions (epoch = current + 1, no overflow) are encoded
+in the function body via `massert` and U64 arithmetic. We express
+them explicitly as hypotheses; they correspond exactly to the
+spec's §3.8 condition and the `hax_lib::assume!` in the Rust source.
+-/
+@[step]
+theorem chain.Chain.add_epoch_spec
+  (self : chain.Chain) (epoch_secret : EpochSecret)
+  (h_no_overflow : self.current_epoch.val + 1 ≤ U64.max)
+  (h_epoch : epoch_secret.epoch.val = self.current_epoch.val + 1) :
+    chain.Chain.add_epoch self epoch_secret
+      ⦃ c' => c'.current_epoch = epoch_secret.epoch ⦄ := by
+  unfold chain.Chain.add_epoch
+  step*
+
+end spqr

--- a/Spqr/Specs/Chain/Key.lean
+++ b/Spqr/Specs/Chain/Key.lean
@@ -1,0 +1,84 @@
+/-
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Spqr.Specs.External
+
+/-! # PROP-17 / PROP-17b: Key Jump Guard and Key Already Requested
+
+Specification and proofs for the `ChainEpochDirection.key` guards
+(PROP-17 and PROP-17b from `docs/mlkembraid_spec/1_scka_interface.md`).
+
+The function dispatches on `at1.cmp(&self.ctr)`:
+- **Equal** (PROP-17b): returns `Err(KeyAlreadyRequested(at1))`
+- **Greater** with excessive jump (PROP-17): returns `Err(KeyJump(ctr, at1))`
+
+**Source**: spqr/src/chain.rs (lines 247:4-296:5)
+-/
+
+open Aeneas Aeneas.Std Result
+
+namespace spqr
+
+/-! ## Helper specs -/
+
+/-- `OrdU32.cmp` lifted into the `Result` monad yields the standard `compare`
+on natural-number values. Required because `lift` is not reducible, so
+`step*` cannot look through it without a dedicated spec. -/
+@[step]
+theorem OrdU32_cmp_spec (x y : Std.U32) :
+    lift (core.cmp.impls.OrdU32.cmp x y)
+      ⦃ o => o = compare x.val y.val ⦄ := by
+  simp only [lift, core.cmp.impls.OrdU32.cmp, WP.spec, WP.theta, WP.wp_return]
+
+/-! ## PROP-17b: Key Already Requested -/
+
+/-- **PROP-17b — Key Already Requested.**
+
+When `at1 = self.ctr`, `ChainEpochDirection.key` returns
+`Err(KeyAlreadyRequested at1)` and the state is unchanged. -/
+@[step]
+theorem chain.ChainEpochDirection.key_already_requested
+    (self : chain.ChainEpochDirection) (at1 : Std.U32)
+    (params : proto.pq_ratchet.ChainParams)
+    (h_eq : at1 = self.ctr) :
+    chain.ChainEpochDirection.key self at1 params ⦃ r =>
+      r.1 = core.result.Result.Err (Error.KeyAlreadyRequested at1) ∧
+      r.2 = self ⦄ := by
+  unfold chain.ChainEpochDirection.key
+  simp [h_eq, lift, core.cmp.impls.OrdU32.cmp, WP.spec, WP.theta, WP.wp_return]
+
+/-! ## PROP-17: Key Jump Guard -/
+
+/-- **PROP-17 — Key Jump Limit.**
+
+When `at1 > self.ctr` and the gap `at1 - self.ctr` exceeds
+`max_jump_or_default(params)`, the function returns
+`Err(KeyJump(ctr, at1))` and the state is unchanged.
+
+The two hypotheses `h_jump_pos` and `h_jump_zero` cover both
+branches of `max_jump_or_default`: when `params.max_jump > 0`
+(custom limit) and when it falls back to the default (25000). -/
+@[step]
+theorem chain.ChainEpochDirection.key_jump_guard
+    (self : chain.ChainEpochDirection) (at1 : Std.U32)
+    (params : proto.pq_ratchet.ChainParams)
+    (h_gt : at1 > self.ctr)
+    (h_jump_pos : params.max_jump > 0#u32 →
+        at1.val - self.ctr.val > params.max_jump.val)
+    (h_jump_zero : ¬(params.max_jump > 0#u32) →
+        at1.val - self.ctr.val > chain.DEFAULT_CHAIN_PARAMS.max_jump.val) :
+    chain.ChainEpochDirection.key self at1 params ⦃ r =>
+      r.1 = core.result.Result.Err (Error.KeyJump self.ctr at1) ∧
+      r.2 = self ⦄ := by
+  unfold chain.ChainEpochDirection.key chain.ChainParams.max_jump_or_default
+  step*
+  · -- .lt branch: impossible since at1 > self.ctr
+    exfalso
+    have h_cmp : compare (↑at1 : ℕ) ↑self.ctr = Ordering.gt := by
+      rw [Nat.compare_eq_gt]; scalar_tac
+    simp_all -- terminal: derives False from contradictory Ordering hypotheses
+  · -- .gt branch: split on max_jump_or_default cases, then show jump check fires
+    split <;> (step*; try scalar_tac)
+
+end spqr

--- a/Spqr/Specs/Chain/SendKey.lean
+++ b/Spqr/Specs/Chain/SendKey.lean
@@ -1,0 +1,46 @@
+/-
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Spqr.Specs.External
+
+/-! # PROP-14: Send Epoch Cannot Decrease
+
+Specification and proof for the `send_key` epoch guard (PROP-14 from
+`docs/mlkembraid_spec/1_scka_interface.md`).
+
+`chain.Chain.send_key(epoch)` returns
+`Err(Error.SendKeyEpochDecreased(send_epoch, epoch))` when
+`epoch < self.send_epoch`. The chain state is returned unchanged.
+
+**Source**: spqr/src/chain.rs (lines 384:4-407:5)
+-/
+
+open Aeneas Aeneas.Std Result
+
+namespace spqr
+
+/-! ## PROP-14: Main theorem -/
+
+/-- **PROP-14 — Send Epoch Cannot Decrease.**
+
+If `epoch < self.send_epoch`, then `chain.Chain.send_key` returns
+an inner `Err(SendKeyEpochDecreased self.send_epoch epoch)` and
+the chain is unchanged.
+
+The outer `Result` (Aeneas monad) succeeds — this is not a panic,
+just a Rust `Err` value returned inside a successful computation.
+-/
+@[step]
+theorem chain.Chain.send_key_epoch_guard
+  (self : chain.Chain) (epoch : Std.U64)
+  (h : epoch < self.send_epoch) :
+    chain.Chain.send_key self epoch
+      ⦃ r => r.1 = core.result.Result.Err
+               (Error.SendKeyEpochDecreased self.send_epoch epoch)
+             ∧ r.2 = self ⦄ := by
+  unfold chain.Chain.send_key
+  simp only [h, ite_true]
+  simp [WP.spec, WP.theta, WP.wp_return] -- full simp set needed to close trivial conjunction
+
+end spqr

--- a/Spqr/Specs/External.lean
+++ b/Spqr/Specs/External.lean
@@ -1,0 +1,86 @@
+/-
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Spqr.Code.Funs
+
+/-! # Liveness axioms
+
+This file collects `@[step]` liveness axioms used across proof files.
+A liveness axiom asserts that a function does not fail, without constraining
+its output: `f args ⦃ _ => True ⦄`.
+
+## Two categories
+
+1. **Opaque functions** (axioms in `FunsExternal.lean`): These have no Lean
+   definition at all — axiomatizing them is the *only* way to reason about them.
+
+2. **Deep defined functions** (defined in `Funs.lean` but with long call chains
+   through encoding, MLKEM, HKDF, etc.): These *could* in principle be proved
+   as `@[step] theorem`s by recursively unfolding and proving each callee, but
+   the effort is disproportionate when the postcondition does not depend on
+   their output. Axiomatizing them is a pragmatic shortcut. Unlike opaque-function
+   axioms, these carry an implicit proof obligation: the defined function
+   must be total on the reachable inputs. Each such axiom documents its
+   soundness rationale in a doc-comment.
+
+## Soundness
+
+All axioms are trusted assumptions. They are sound as long as the
+underlying Rust implementations do not panic on the inputs reachable
+from the extracted code paths.
+-/
+
+open Aeneas Aeneas.Std Result
+
+namespace spqr
+
+/-! ## Category 1: Opaque functions (`FunsExternal.lean`) -/
+
+/-- The HKDF-based KDF call succeeds for any input slices.
+Soundness: HKDF-SHA256 is total on arbitrary byte inputs. -/
+@[step]
+axiom kdf.hkdf_to_slice_spec
+    (salt ikm info out : Slice Std.U8) :
+    kdf.hkdf_to_slice salt ikm info out ⦃ _ => True ⦄
+
+/-- Appending an element to a `VecDeque` always succeeds.
+Soundness: `push_back` only fails on OOM, which Rust treats as an abort. -/
+@[step]
+axiom alloc.collections.vec_deque.VecDeque.push_back_spec
+    {T A : Type} (vd : alloc.collections.vec_deque.VecDeque T A) (val : T) :
+    alloc.collections.vec_deque.VecDeque.push_back vd val ⦃ _ => True ⦄
+
+/-! ## Category 2: Deep defined functions (`Funs.lean`)
+
+These functions are fully extracted and could be proved as theorems, but their
+call chains are deep (encoding loops, MLKEM operations, HKDF derivations).
+Axiomatizing them is a pragmatic shortcut; see the file-level doc for policy.
+-/
+
+/-- `PolyEncoder.next_chunk` always succeeds. -/
+@[step]
+axiom encoding.polynomial.PolyEncoder.Insts.SpqrEncodingEncoder.next_chunk_spec
+    (self : encoding.polynomial.PolyEncoder) :
+    encoding.polynomial.PolyEncoder.Insts.SpqrEncodingEncoder.next_chunk self
+      ⦃ _ => True ⦄
+
+/-- `KeysUnsampled.send_hdr_chunk` always succeeds (performs header sampling
+    with RNG + MLKEM key generation + encoding). -/
+@[step]
+axiom v1.chunked.send_ek.KeysUnsampled.send_hdr_chunk_spec
+    {R : Type} (rng_inst : rand.rng.Rng R) (crypto_inst : rand_core.CryptoRng R)
+    (self : v1.chunked.send_ek.KeysUnsampled) (rng : R) :
+    v1.chunked.send_ek.KeysUnsampled.send_hdr_chunk rng_inst crypto_inst self rng
+      ⦃ _ => True ⦄
+
+/-- `HeaderReceived.send_ct1_chunk` always succeeds (performs CT1 sampling
+    with RNG + MLKEM encapsulation + epoch secret derivation + encoding). -/
+@[step]
+axiom v1.chunked.send_ct.HeaderReceived.send_ct1_chunk_spec
+    {R : Type} (rng_inst : rand.rng.Rng R) (crypto_inst : rand_core.CryptoRng R)
+    (self : v1.chunked.send_ct.HeaderReceived) (rng : R) :
+    v1.chunked.send_ct.HeaderReceived.send_ct1_chunk rng_inst crypto_inst self rng
+      ⦃ _ => True ⦄
+
+end spqr

--- a/Spqr/Specs/States/Recv.lean
+++ b/Spqr/Specs/States/Recv.lean
@@ -1,0 +1,356 @@
+/-
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Spqr.Specs.External
+
+/-! # PROP-26 + PROP-39: Epoch Guards for `States.recv`
+
+Specifications and proofs for epoch guards on `States.recv`
+(PROP-26 and PROP-39 from `docs/mlkembraid_spec/3_protocol.md`).
+
+**PROP-26:** In the Ct2Sampled state, messages from future epochs beyond
+`epoch + 1` are rejected with `EpochOutOfRange`.
+
+**PROP-39:** For all 10 non-Ct2Sampled state variants, any message with
+`msg.epoch > state.epoch` is rejected with `EpochOutOfRange`.
+
+**Source**: spqr/src/v1/chunked/states.rs (lines 275-532)
+-/
+
+open Aeneas Aeneas.Std Result
+
+namespace spqr
+
+/-! ## Helper specs -/
+
+/-- `OrdU64.cmp` lifted into `Result` yields `compare` on `.val`. -/
+@[step]
+theorem OrdU64_cmp_spec (x y : Std.U64) :
+    lift (core.cmp.impls.OrdU64.cmp x y)
+      ⦃ o => o = compare x.val y.val ⦄ := by
+  simp only [lift, core.cmp.impls.OrdU64.cmp, WP.spec, WP.theta, WP.wp_return]
+
+/-! ## PROP-26: Main theorem -/
+
+/-- **PROP-26 — Ct2Sampled future epoch guard.**
+
+When `msg.epoch > state.uc.epoch + 1` (at the ℕ level), `States.recv`
+on a `Ct2Sampled` state returns `Err(EpochOutOfRange msg.epoch)`. -/
+@[step]
+theorem v1.chunked.states.States.recv_Ct2Sampled_future_epoch_guard
+    (state : v1.chunked.send_ct.Ct2Sampled)
+    (msg : v1.chunked.states.Message)
+    (h : msg.epoch.val > state.uc.epoch.val + 1) :
+    v1.chunked.states.States.recv
+      (v1.chunked.states.States.Ct2Sampled state) msg ⦃ r =>
+      r = core.result.Result.Err (Error.EpochOutOfRange msg.epoch) ⦄ := by
+  unfold v1.chunked.states.States.recv v1.chunked.send_ct.Ct2Sampled.epoch
+  step*
+  -- .lt branch: impossible (msg.epoch > state.uc.epoch)
+  exfalso
+  have h_cmp : compare (↑msg.epoch : ℕ) ↑state.uc.epoch = Ordering.gt := by
+    rw [Nat.compare_eq_gt]; scalar_tac
+  simp_all -- terminal: derives False from contradictory Ordering hypotheses
+
+/-! ## PROP-39: Greater-branch guards for all non-Ct2Sampled variants
+
+For each variant, when `msg.epoch > state.epoch()`, `States.recv` returns
+`Err(EpochOutOfRange msg.epoch)`. All 10 proofs follow the same pattern:
+unfold `recv` + the variant's `.epoch`, run `step*`, and dismiss the
+impossible `.lt` branch by contradiction on the `compare` result.
+-/
+
+private theorem gt_branch_contradiction
+  {ep_msg ep_state : ℕ} {o : Ordering}
+  (h_gt : ep_msg > ep_state)
+  (o_post : o = compare ep_msg ep_state)
+  (h_lt : o = Ordering.lt) : False := by
+  have : compare ep_msg ep_state = Ordering.gt := by
+    rw [Nat.compare_eq_gt]; omega
+  simp_all -- terminal: derives False from contradictory Ordering hypotheses
+
+/-- **PROP-39 (KeysUnsampled)** — Greater-branch returns `EpochOutOfRange`. -/
+@[step]
+theorem v1.chunked.states.States.recv_KeysUnsampled_gt_guard
+    (state : v1.chunked.send_ek.KeysUnsampled)
+    (msg : v1.chunked.states.Message)
+    (h : msg.epoch > state.uc.epoch) :
+    v1.chunked.states.States.recv
+      (v1.chunked.states.States.KeysUnsampled state) msg ⦃ r =>
+      r = core.result.Result.Err (Error.EpochOutOfRange msg.epoch) ⦄ := by
+  unfold v1.chunked.states.States.recv v1.chunked.send_ek.KeysUnsampled.epoch
+  step*; exfalso; exact gt_branch_contradiction (by scalar_tac) o_post ‹_›
+
+/-- **PROP-39 (KeysSampled)** — Greater-branch returns `EpochOutOfRange`. -/
+@[step]
+theorem v1.chunked.states.States.recv_KeysSampled_gt_guard
+    (state : v1.chunked.send_ek.KeysSampled)
+    (msg : v1.chunked.states.Message)
+    (h : msg.epoch > state.uc.epoch) :
+    v1.chunked.states.States.recv
+      (v1.chunked.states.States.KeysSampled state) msg ⦃ r =>
+      r = core.result.Result.Err (Error.EpochOutOfRange msg.epoch) ⦄ := by
+  unfold v1.chunked.states.States.recv v1.chunked.send_ek.KeysSampled.epoch
+  step*; exfalso; exact gt_branch_contradiction (by scalar_tac) o_post ‹_›
+
+/-- **PROP-39 (HeaderSent)** — Greater-branch returns `EpochOutOfRange`. -/
+@[step]
+theorem v1.chunked.states.States.recv_HeaderSent_gt_guard
+    (state : v1.chunked.send_ek.HeaderSent)
+    (msg : v1.chunked.states.Message)
+    (h : msg.epoch > state.uc.epoch) :
+    v1.chunked.states.States.recv
+      (v1.chunked.states.States.HeaderSent state) msg ⦃ r =>
+      r = core.result.Result.Err (Error.EpochOutOfRange msg.epoch) ⦄ := by
+  unfold v1.chunked.states.States.recv v1.chunked.send_ek.HeaderSent.epoch
+  step*; exfalso; exact gt_branch_contradiction (by scalar_tac) o_post ‹_›
+
+/-- **PROP-39 (Ct1Received)** — Greater-branch returns `EpochOutOfRange`. -/
+@[step]
+theorem v1.chunked.states.States.recv_Ct1Received_gt_guard
+    (state : v1.chunked.send_ek.Ct1Received)
+    (msg : v1.chunked.states.Message)
+    (h : msg.epoch > state.uc.epoch) :
+    v1.chunked.states.States.recv
+      (v1.chunked.states.States.Ct1Received state) msg ⦃ r =>
+      r = core.result.Result.Err (Error.EpochOutOfRange msg.epoch) ⦄ := by
+  unfold v1.chunked.states.States.recv v1.chunked.send_ek.Ct1Received.epoch
+  step*; exfalso; exact gt_branch_contradiction (by scalar_tac) o_post ‹_›
+
+/-- **PROP-39 (EkSentCt1Received)** — Greater-branch returns `EpochOutOfRange`. -/
+@[step]
+theorem v1.chunked.states.States.recv_EkSentCt1Received_gt_guard
+    (state : v1.chunked.send_ek.EkSentCt1Received)
+    (msg : v1.chunked.states.Message)
+    (h : msg.epoch > state.uc.epoch) :
+    v1.chunked.states.States.recv
+      (v1.chunked.states.States.EkSentCt1Received state) msg ⦃ r =>
+      r = core.result.Result.Err (Error.EpochOutOfRange msg.epoch) ⦄ := by
+  unfold v1.chunked.states.States.recv v1.chunked.send_ek.EkSentCt1Received.epoch
+  step*; exfalso; exact gt_branch_contradiction (by scalar_tac) o_post ‹_›
+
+/-- **PROP-39 (NoHeaderReceived)** — Greater-branch returns `EpochOutOfRange`. -/
+@[step]
+theorem v1.chunked.states.States.recv_NoHeaderReceived_gt_guard
+    (state : v1.chunked.send_ct.NoHeaderReceived)
+    (msg : v1.chunked.states.Message)
+    (h : msg.epoch > state.uc.epoch) :
+    v1.chunked.states.States.recv
+      (v1.chunked.states.States.NoHeaderReceived state) msg ⦃ r =>
+      r = core.result.Result.Err (Error.EpochOutOfRange msg.epoch) ⦄ := by
+  unfold v1.chunked.states.States.recv v1.chunked.send_ct.NoHeaderReceived.epoch
+  step*; exfalso; exact gt_branch_contradiction (by scalar_tac) o_post ‹_›
+
+/-- **PROP-39 (HeaderReceived)** — Greater-branch returns `EpochOutOfRange`. -/
+@[step]
+theorem v1.chunked.states.States.recv_HeaderReceived_gt_guard
+    (state : v1.chunked.send_ct.HeaderReceived)
+    (msg : v1.chunked.states.Message)
+    (h : msg.epoch > state.uc.epoch) :
+    v1.chunked.states.States.recv
+      (v1.chunked.states.States.HeaderReceived state) msg ⦃ r =>
+      r = core.result.Result.Err (Error.EpochOutOfRange msg.epoch) ⦄ := by
+  unfold v1.chunked.states.States.recv v1.chunked.send_ct.HeaderReceived.epoch
+  step*; exfalso; exact gt_branch_contradiction (by scalar_tac) o_post ‹_›
+
+/-- **PROP-39 (Ct1Sampled)** — Greater-branch returns `EpochOutOfRange`. -/
+@[step]
+theorem v1.chunked.states.States.recv_Ct1Sampled_gt_guard
+    (state : v1.chunked.send_ct.Ct1Sampled)
+    (msg : v1.chunked.states.Message)
+    (h : msg.epoch > state.uc.epoch) :
+    v1.chunked.states.States.recv
+      (v1.chunked.states.States.Ct1Sampled state) msg ⦃ r =>
+      r = core.result.Result.Err (Error.EpochOutOfRange msg.epoch) ⦄ := by
+  unfold v1.chunked.states.States.recv v1.chunked.send_ct.Ct1Sampled.epoch
+  step*; exfalso; exact gt_branch_contradiction (by scalar_tac) o_post ‹_›
+
+/-- **PROP-39 (EkReceivedCt1Sampled)** — Greater-branch returns `EpochOutOfRange`. -/
+@[step]
+theorem v1.chunked.states.States.recv_EkReceivedCt1Sampled_gt_guard
+    (state : v1.chunked.send_ct.EkReceivedCt1Sampled)
+    (msg : v1.chunked.states.Message)
+    (h : msg.epoch > state.uc.epoch) :
+    v1.chunked.states.States.recv
+      (v1.chunked.states.States.EkReceivedCt1Sampled state) msg ⦃ r =>
+      r = core.result.Result.Err (Error.EpochOutOfRange msg.epoch) ⦄ := by
+  unfold v1.chunked.states.States.recv v1.chunked.send_ct.EkReceivedCt1Sampled.epoch
+  step*; exfalso; exact gt_branch_contradiction (by scalar_tac) o_post ‹_›
+
+/-- **PROP-39 (Ct1Acknowledged)** — Greater-branch returns `EpochOutOfRange`. -/
+@[step]
+theorem v1.chunked.states.States.recv_Ct1Acknowledged_gt_guard
+    (state : v1.chunked.send_ct.Ct1Acknowledged)
+    (msg : v1.chunked.states.Message)
+    (h : msg.epoch > state.uc.epoch) :
+    v1.chunked.states.States.recv
+      (v1.chunked.states.States.Ct1Acknowledged state) msg ⦃ r =>
+      r = core.result.Result.Err (Error.EpochOutOfRange msg.epoch) ⦄ := by
+  unfold v1.chunked.states.States.recv v1.chunked.send_ct.Ct1Acknowledged.epoch
+  step*; exfalso; exact gt_branch_contradiction (by scalar_tac) o_post ‹_›
+
+/-! ## PROP-30: Less-branch no-op for all variants
+
+For each variant, when `msg.epoch < state.epoch()`, `States.recv` returns
+`Ok { key := none, state := self }` — a no-op. The proof pattern mirrors
+PROP-39: unfold `recv` + the variant's `.epoch`, run `step*`, and dismiss
+the impossible `.gt` branch by contradiction.
+-/
+
+private theorem lt_branch_contradiction
+  {ep_msg ep_state : ℕ} {o : Ordering}
+  (h_lt : ep_msg < ep_state)
+  (o_post : o = compare ep_msg ep_state)
+  (h_gt : o = Ordering.gt) : False := by
+  have : compare ep_msg ep_state = Ordering.lt := by
+    rw [Nat.compare_eq_lt]; omega
+  simp_all -- terminal: derives False from contradictory Ordering hypotheses
+
+/-- **PROP-30 (KeysUnsampled)** — Less-branch is no-op. -/
+@[step]
+theorem v1.chunked.states.States.recv_KeysUnsampled_lt_noop
+    (state : v1.chunked.send_ek.KeysUnsampled)
+    (msg : v1.chunked.states.Message)
+    (h : msg.epoch < state.uc.epoch) :
+    v1.chunked.states.States.recv
+      (v1.chunked.states.States.KeysUnsampled state) msg ⦃ r =>
+      r = core.result.Result.Ok
+        { key := none, state := v1.chunked.states.States.KeysUnsampled state } ⦄ := by
+  unfold v1.chunked.states.States.recv v1.chunked.send_ek.KeysUnsampled.epoch
+  step*; exfalso; exact lt_branch_contradiction (by scalar_tac) o_post ‹_›
+
+/-- **PROP-30 (KeysSampled)** — Less-branch is no-op. -/
+@[step]
+theorem v1.chunked.states.States.recv_KeysSampled_lt_noop
+    (state : v1.chunked.send_ek.KeysSampled)
+    (msg : v1.chunked.states.Message)
+    (h : msg.epoch < state.uc.epoch) :
+    v1.chunked.states.States.recv
+      (v1.chunked.states.States.KeysSampled state) msg ⦃ r =>
+      r = core.result.Result.Ok
+        { key := none, state := v1.chunked.states.States.KeysSampled state } ⦄ := by
+  unfold v1.chunked.states.States.recv v1.chunked.send_ek.KeysSampled.epoch
+  step*; exfalso; exact lt_branch_contradiction (by scalar_tac) o_post ‹_›
+
+/-- **PROP-30 (HeaderSent)** — Less-branch is no-op. -/
+@[step]
+theorem v1.chunked.states.States.recv_HeaderSent_lt_noop
+    (state : v1.chunked.send_ek.HeaderSent)
+    (msg : v1.chunked.states.Message)
+    (h : msg.epoch < state.uc.epoch) :
+    v1.chunked.states.States.recv
+      (v1.chunked.states.States.HeaderSent state) msg ⦃ r =>
+      r = core.result.Result.Ok
+        { key := none, state := v1.chunked.states.States.HeaderSent state } ⦄ := by
+  unfold v1.chunked.states.States.recv v1.chunked.send_ek.HeaderSent.epoch
+  step*; exfalso; exact lt_branch_contradiction (by scalar_tac) o_post ‹_›
+
+/-- **PROP-30 (Ct1Received)** — Less-branch is no-op. -/
+@[step]
+theorem v1.chunked.states.States.recv_Ct1Received_lt_noop
+    (state : v1.chunked.send_ek.Ct1Received)
+    (msg : v1.chunked.states.Message)
+    (h : msg.epoch < state.uc.epoch) :
+    v1.chunked.states.States.recv
+      (v1.chunked.states.States.Ct1Received state) msg ⦃ r =>
+      r = core.result.Result.Ok
+        { key := none, state := v1.chunked.states.States.Ct1Received state } ⦄ := by
+  unfold v1.chunked.states.States.recv v1.chunked.send_ek.Ct1Received.epoch
+  step*; exfalso; exact lt_branch_contradiction (by scalar_tac) o_post ‹_›
+
+/-- **PROP-30 (EkSentCt1Received)** — Less-branch is no-op. -/
+@[step]
+theorem v1.chunked.states.States.recv_EkSentCt1Received_lt_noop
+    (state : v1.chunked.send_ek.EkSentCt1Received)
+    (msg : v1.chunked.states.Message)
+    (h : msg.epoch < state.uc.epoch) :
+    v1.chunked.states.States.recv
+      (v1.chunked.states.States.EkSentCt1Received state) msg ⦃ r =>
+      r = core.result.Result.Ok
+        { key := none,
+          state := v1.chunked.states.States.EkSentCt1Received state } ⦄ := by
+  unfold v1.chunked.states.States.recv v1.chunked.send_ek.EkSentCt1Received.epoch
+  step*; exfalso; exact lt_branch_contradiction (by scalar_tac) o_post ‹_›
+
+/-- **PROP-30 (NoHeaderReceived)** — Less-branch is no-op. -/
+@[step]
+theorem v1.chunked.states.States.recv_NoHeaderReceived_lt_noop
+    (state : v1.chunked.send_ct.NoHeaderReceived)
+    (msg : v1.chunked.states.Message)
+    (h : msg.epoch < state.uc.epoch) :
+    v1.chunked.states.States.recv
+      (v1.chunked.states.States.NoHeaderReceived state) msg ⦃ r =>
+      r = core.result.Result.Ok
+        { key := none, state := v1.chunked.states.States.NoHeaderReceived state } ⦄ := by
+  unfold v1.chunked.states.States.recv v1.chunked.send_ct.NoHeaderReceived.epoch
+  step*; exfalso; exact lt_branch_contradiction (by scalar_tac) o_post ‹_›
+
+/-- **PROP-30 (HeaderReceived)** — Less-branch is no-op. -/
+@[step]
+theorem v1.chunked.states.States.recv_HeaderReceived_lt_noop
+    (state : v1.chunked.send_ct.HeaderReceived)
+    (msg : v1.chunked.states.Message)
+    (h : msg.epoch < state.uc.epoch) :
+    v1.chunked.states.States.recv
+      (v1.chunked.states.States.HeaderReceived state) msg ⦃ r =>
+      r = core.result.Result.Ok
+        { key := none, state := v1.chunked.states.States.HeaderReceived state } ⦄ := by
+  unfold v1.chunked.states.States.recv v1.chunked.send_ct.HeaderReceived.epoch
+  step*; exfalso; exact lt_branch_contradiction (by scalar_tac) o_post ‹_›
+
+/-- **PROP-30 (Ct1Sampled)** — Less-branch is no-op. -/
+@[step]
+theorem v1.chunked.states.States.recv_Ct1Sampled_lt_noop
+    (state : v1.chunked.send_ct.Ct1Sampled)
+    (msg : v1.chunked.states.Message)
+    (h : msg.epoch < state.uc.epoch) :
+    v1.chunked.states.States.recv
+      (v1.chunked.states.States.Ct1Sampled state) msg ⦃ r =>
+      r = core.result.Result.Ok
+        { key := none, state := v1.chunked.states.States.Ct1Sampled state } ⦄ := by
+  unfold v1.chunked.states.States.recv v1.chunked.send_ct.Ct1Sampled.epoch
+  step*; exfalso; exact lt_branch_contradiction (by scalar_tac) o_post ‹_›
+
+/-- **PROP-30 (EkReceivedCt1Sampled)** — Less-branch is no-op. -/
+@[step]
+theorem v1.chunked.states.States.recv_EkReceivedCt1Sampled_lt_noop
+    (state : v1.chunked.send_ct.EkReceivedCt1Sampled)
+    (msg : v1.chunked.states.Message)
+    (h : msg.epoch < state.uc.epoch) :
+    v1.chunked.states.States.recv
+      (v1.chunked.states.States.EkReceivedCt1Sampled state) msg ⦃ r =>
+      r = core.result.Result.Ok
+        { key := none,
+          state := v1.chunked.states.States.EkReceivedCt1Sampled state } ⦄ := by
+  unfold v1.chunked.states.States.recv v1.chunked.send_ct.EkReceivedCt1Sampled.epoch
+  step*; exfalso; exact lt_branch_contradiction (by scalar_tac) o_post ‹_›
+
+/-- **PROP-30 (Ct1Acknowledged)** — Less-branch is no-op. -/
+@[step]
+theorem v1.chunked.states.States.recv_Ct1Acknowledged_lt_noop
+    (state : v1.chunked.send_ct.Ct1Acknowledged)
+    (msg : v1.chunked.states.Message)
+    (h : msg.epoch < state.uc.epoch) :
+    v1.chunked.states.States.recv
+      (v1.chunked.states.States.Ct1Acknowledged state) msg ⦃ r =>
+      r = core.result.Result.Ok
+        { key := none, state := v1.chunked.states.States.Ct1Acknowledged state } ⦄ := by
+  unfold v1.chunked.states.States.recv v1.chunked.send_ct.Ct1Acknowledged.epoch
+  step*; exfalso; exact lt_branch_contradiction (by scalar_tac) o_post ‹_›
+
+/-- **PROP-30 (Ct2Sampled)** — Less-branch is no-op. -/
+@[step]
+theorem v1.chunked.states.States.recv_Ct2Sampled_lt_noop
+    (state : v1.chunked.send_ct.Ct2Sampled)
+    (msg : v1.chunked.states.Message)
+    (h : msg.epoch < state.uc.epoch) :
+    v1.chunked.states.States.recv
+      (v1.chunked.states.States.Ct2Sampled state) msg ⦃ r =>
+      r = core.result.Result.Ok
+        { key := none, state := v1.chunked.states.States.Ct2Sampled state } ⦄ := by
+  unfold v1.chunked.states.States.recv v1.chunked.send_ct.Ct2Sampled.epoch
+  step*
+  all_goals (exfalso; exact lt_branch_contradiction (by scalar_tac) o_post ‹_›)
+
+end spqr

--- a/Spqr/Specs/States/Send.lean
+++ b/Spqr/Specs/States/Send.lean
@@ -1,0 +1,196 @@
+/-
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Spqr.Specs.External
+
+/-! # States.send Specifications
+
+Specifications and proofs for branches of `States.send`
+(PROP-33 from `docs/mlkembraid_spec/3_protocol.md` and PROP-21 from `docs/mlkembraid_spec/1_scka_interface.md`).
+
+**PROP-33:** In the `EkSentCt1Received` state, `send` emits `Ct1Ack(true)`.
+
+**PROP-21:** For 10 of 11 state variants, `send` emits `key = none`.
+The exception is `HeaderReceived`, which emits `key = some epoch_secret`.
+Three variants (EkSentCt1Received, NoHeaderReceived, Ct1Acknowledged) need
+no axioms; the other 7 rely on liveness axioms for `next_chunk` (encoding)
+and `send_hdr_chunk`/`send_ct1_chunk` (crypto+RNG) from `External.lean`.
+
+**Source**: spqr/src/v1/chunked/states.rs (lines 139-268)
+-/
+
+open Aeneas Aeneas.Std Result
+
+namespace spqr
+
+/-! ## PROP-33: Main theorem -/
+
+/-- **PROP-33 — EkSentCt1Received.send emits Ct1Ack(true).**
+
+When the state machine is in `EkSentCt1Received`, `States.send` returns
+`Ok` with `msg.payload = Ct1Ack true`, `key = none`, and state unchanged.
+This is a deviation flag: the spec's `Ct1Ack` carries no boolean, but the
+implementation always sends `true` here. -/
+@[step]
+theorem v1.chunked.states.States.send_EkSentCt1Received_ct1_ack
+    {R : Type} (rng_inst : rand.rng.Rng R) (crypto_inst : rand_core.CryptoRng R)
+    (state : v1.chunked.send_ek.EkSentCt1Received) (rng : R) :
+    v1.chunked.states.States.send rng_inst crypto_inst
+      (v1.chunked.states.States.EkSentCt1Received state) rng ⦃ r =>
+      ∃ s, r.1 = core.result.Result.Ok s ∧
+      s.msg.payload = v1.chunked.states.MessagePayload.Ct1Ack true ∧
+      s.key = none ∧
+      s.state = v1.chunked.states.States.EkSentCt1Received state ∧
+      r.2 = rng ⦄ := by
+  unfold v1.chunked.states.States.send v1.chunked.send_ek.EkSentCt1Received.epoch
+  step*
+
+/-! ## PROP-21 (partial): NoHeaderReceived.send and Ct1Acknowledged.send -/
+
+/-- **PROP-21 partial (NoHeaderReceived)** — `send` emits `payload = None`,
+`key = none`, state unchanged, RNG not consumed. -/
+@[step]
+theorem v1.chunked.states.States.send_NoHeaderReceived_noop
+    {R : Type} (rng_inst : rand.rng.Rng R) (crypto_inst : rand_core.CryptoRng R)
+    (state : v1.chunked.send_ct.NoHeaderReceived) (rng : R) :
+    v1.chunked.states.States.send rng_inst crypto_inst
+      (v1.chunked.states.States.NoHeaderReceived state) rng ⦃ r =>
+      ∃ s, r.1 = core.result.Result.Ok s ∧
+      s.msg.payload = v1.chunked.states.MessagePayload.None ∧
+      s.key = none ∧
+      s.state = v1.chunked.states.States.NoHeaderReceived state ∧
+      r.2 = rng ⦄ := by
+  unfold v1.chunked.states.States.send v1.chunked.send_ct.NoHeaderReceived.epoch
+  step*
+
+/-- **PROP-21 partial (Ct1Acknowledged)** — `send` emits `payload = None`,
+`key = none`, state unchanged, RNG not consumed. -/
+@[step]
+theorem v1.chunked.states.States.send_Ct1Acknowledged_noop
+    {R : Type} (rng_inst : rand.rng.Rng R) (crypto_inst : rand_core.CryptoRng R)
+    (state : v1.chunked.send_ct.Ct1Acknowledged) (rng : R) :
+    v1.chunked.states.States.send rng_inst crypto_inst
+      (v1.chunked.states.States.Ct1Acknowledged state) rng ⦃ r =>
+      ∃ s, r.1 = core.result.Result.Ok s ∧
+      s.msg.payload = v1.chunked.states.MessagePayload.None ∧
+      s.key = none ∧
+      s.state = v1.chunked.states.States.Ct1Acknowledged state ∧
+      r.2 = rng ⦄ := by
+  unfold v1.chunked.states.States.send v1.chunked.send_ct.Ct1Acknowledged.epoch
+  step*
+
+/-! ## PROP-21: Remaining key=none variants (axiom-backed)
+
+The following 7 variants call helper functions before returning `key := none`.
+The proofs unfold `States.send`, the variant's `.epoch`, and (for simple helpers)
+the helper itself to expose the `next_chunk` call. For the complex
+`KeysUnsampled.send_hdr_chunk`, the axiom is at the helper level.
+-/
+
+/-- **PROP-21 (KeysUnsampled)** — `send` emits `key = none`.
+Uses liveness axiom for `send_hdr_chunk` (complex: RNG + MLKEM). -/
+@[step]
+theorem v1.chunked.states.States.send_KeysUnsampled_key_none
+    {R : Type} (rng_inst : rand.rng.Rng R) (crypto_inst : rand_core.CryptoRng R)
+    (state : v1.chunked.send_ek.KeysUnsampled) (rng : R) :
+    v1.chunked.states.States.send rng_inst crypto_inst
+      (v1.chunked.states.States.KeysUnsampled state) rng ⦃ r =>
+      ∃ s, r.1 = core.result.Result.Ok s ∧ s.key = none ⦄ := by
+  unfold v1.chunked.states.States.send v1.chunked.send_ek.KeysUnsampled.epoch
+  step*
+
+/-- **PROP-21 (KeysSampled)** — `send` emits `key = none`.
+Uses liveness axiom for `next_chunk`. -/
+@[step]
+theorem v1.chunked.states.States.send_KeysSampled_key_none
+    {R : Type} (rng_inst : rand.rng.Rng R) (crypto_inst : rand_core.CryptoRng R)
+    (state : v1.chunked.send_ek.KeysSampled) (rng : R) :
+    v1.chunked.states.States.send rng_inst crypto_inst
+      (v1.chunked.states.States.KeysSampled state) rng ⦃ r =>
+      ∃ s, r.1 = core.result.Result.Ok s ∧ s.key = none ⦄ := by
+  unfold v1.chunked.states.States.send v1.chunked.send_ek.KeysSampled.epoch
+    v1.chunked.send_ek.KeysSampled.send_hdr_chunk
+  step*
+
+/-- **PROP-21 (HeaderSent)** — `send` emits `key = none`.
+Uses liveness axiom for `next_chunk`. -/
+@[step]
+theorem v1.chunked.states.States.send_HeaderSent_key_none
+    {R : Type} (rng_inst : rand.rng.Rng R) (crypto_inst : rand_core.CryptoRng R)
+    (state : v1.chunked.send_ek.HeaderSent) (rng : R) :
+    v1.chunked.states.States.send rng_inst crypto_inst
+      (v1.chunked.states.States.HeaderSent state) rng ⦃ r =>
+      ∃ s, r.1 = core.result.Result.Ok s ∧ s.key = none ⦄ := by
+  unfold v1.chunked.states.States.send v1.chunked.send_ek.HeaderSent.epoch
+    v1.chunked.send_ek.HeaderSent.send_ek_chunk
+  step*
+
+/-- **PROP-21 (Ct1Received)** — `send` emits `key = none`.
+Uses liveness axiom for `next_chunk`. -/
+@[step]
+theorem v1.chunked.states.States.send_Ct1Received_key_none
+    {R : Type} (rng_inst : rand.rng.Rng R) (crypto_inst : rand_core.CryptoRng R)
+    (state : v1.chunked.send_ek.Ct1Received) (rng : R) :
+    v1.chunked.states.States.send rng_inst crypto_inst
+      (v1.chunked.states.States.Ct1Received state) rng ⦃ r =>
+      ∃ s, r.1 = core.result.Result.Ok s ∧ s.key = none ⦄ := by
+  unfold v1.chunked.states.States.send v1.chunked.send_ek.Ct1Received.epoch
+    v1.chunked.send_ek.Ct1Received.send_ek_chunk
+  step*
+
+/-- **PROP-21 (Ct1Sampled)** — `send` emits `key = none`.
+Uses liveness axiom for `next_chunk`. -/
+@[step]
+theorem v1.chunked.states.States.send_Ct1Sampled_key_none
+    {R : Type} (rng_inst : rand.rng.Rng R) (crypto_inst : rand_core.CryptoRng R)
+    (state : v1.chunked.send_ct.Ct1Sampled) (rng : R) :
+    v1.chunked.states.States.send rng_inst crypto_inst
+      (v1.chunked.states.States.Ct1Sampled state) rng ⦃ r =>
+      ∃ s, r.1 = core.result.Result.Ok s ∧ s.key = none ⦄ := by
+  unfold v1.chunked.states.States.send v1.chunked.send_ct.Ct1Sampled.epoch
+    v1.chunked.send_ct.Ct1Sampled.send_ct1_chunk
+  step*
+
+/-- **PROP-21 (EkReceivedCt1Sampled)** — `send` emits `key = none`.
+Uses liveness axiom for `next_chunk`. -/
+@[step]
+theorem v1.chunked.states.States.send_EkReceivedCt1Sampled_key_none
+    {R : Type} (rng_inst : rand.rng.Rng R) (crypto_inst : rand_core.CryptoRng R)
+    (state : v1.chunked.send_ct.EkReceivedCt1Sampled) (rng : R) :
+    v1.chunked.states.States.send rng_inst crypto_inst
+      (v1.chunked.states.States.EkReceivedCt1Sampled state) rng ⦃ r =>
+      ∃ s, r.1 = core.result.Result.Ok s ∧ s.key = none ⦄ := by
+  unfold v1.chunked.states.States.send v1.chunked.send_ct.EkReceivedCt1Sampled.epoch
+    v1.chunked.send_ct.EkReceivedCt1Sampled.send_ct1_chunk
+  step*
+
+/-- **PROP-21 (Ct2Sampled)** — `send` emits `key = none`.
+Uses liveness axiom for `next_chunk`. -/
+@[step]
+theorem v1.chunked.states.States.send_Ct2Sampled_key_none
+    {R : Type} (rng_inst : rand.rng.Rng R) (crypto_inst : rand_core.CryptoRng R)
+    (state : v1.chunked.send_ct.Ct2Sampled) (rng : R) :
+    v1.chunked.states.States.send rng_inst crypto_inst
+      (v1.chunked.states.States.Ct2Sampled state) rng ⦃ r =>
+      ∃ s, r.1 = core.result.Result.Ok s ∧ s.key = none ⦄ := by
+  unfold v1.chunked.states.States.send v1.chunked.send_ct.Ct2Sampled.epoch
+    v1.chunked.send_ct.Ct2Sampled.send_ct2_chunk
+  step*
+
+/-! ## PROP-21 positive case: HeaderReceived emits a key -/
+
+/-- **PROP-21 (HeaderReceived)** — `send` emits `key = some _`.
+This is the one variant where `send` produces an epoch secret.
+Uses liveness axiom for `send_ct1_chunk` (complex: RNG + MLKEM). -/
+@[step]
+theorem v1.chunked.states.States.send_HeaderReceived_key_some
+    {R : Type} (rng_inst : rand.rng.Rng R) (crypto_inst : rand_core.CryptoRng R)
+    (state : v1.chunked.send_ct.HeaderReceived) (rng : R) :
+    v1.chunked.states.States.send rng_inst crypto_inst
+      (v1.chunked.states.States.HeaderReceived state) rng ⦃ r =>
+      ∃ s, r.1 = core.result.Result.Ok s ∧ s.key.isSome ⦄ := by
+  unfold v1.chunked.states.States.send v1.chunked.send_ct.HeaderReceived.epoch
+  step*
+
+end spqr


### PR DESCRIPTION
This PR adds Lean proofs for 9 protocol-level properties over the chain
module and the v1 chunked state machine. Property IDs refer to the catalog
in `docs/mlkembraid_spec/`.

Chain proofs (`Spqr/Specs/Chain/`):
- PROP-9: epoch monotonicity — add_epoch increments current_epoch
- PROP-14: send key guard — send_key rejects epoch < current_epoch
- PROP-17/17b: key jump guard — key rejects out-of-range epochs

State machine proofs (`Spqr/Specs/States/`):
- PROP-33: EkSentCt1Received.send emits Ct1Ack(true)
- PROP-21: only HeaderReceived.send emits a key (10 other variants emit none)
- PROP-26: Ct2Sampled epoch guard
- PROP-39: greater-branch EpochOutOfRange (10 variants)
- PROP-30: less-branch no-op (11 variants)

Axiom infrastructure (`Spqr/Specs/External.lean`):
- Liveness axioms for opaque functions (hkdf, VecDeque) and deep-defined
  functions (next_chunk, send_hdr_chunk, send_ct1_chunk)

No `sorry` in any of the new proof files.

closes #44

Made with [Cursor](https://cursor.com)