### PR TITLE
ci: move sorry-delta comment to workflow_run for fork PR support

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -61,6 +61,10 @@ jobs:
           key: sorry-manifest-main-${{ github.sha }}
           path: sorry-manifest.txt
 
+      - name: Save PR number
+        if: github.event_name == 'pull_request'
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+
       - name: Upload sorry manifests
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
@@ -69,37 +73,6 @@ jobs:
           path: |
             sorry-manifest.txt
             sorry-manifest-base.txt
+            pr-number.txt
           if-no-files-found: ignore
           retention-days: 1
-
-  report-sorry-delta:
-    name: Report Sorry Delta
-    if: github.event_name == 'pull_request'
-    needs: build
-    runs-on: ubuntu-latest
-    # Write permissions are isolated to this lightweight job.
-    # For fork PRs the token is read-only; the action degrades gracefully.
-    permissions:
-      contents: read
-      pull-requests: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: scripts/
-
-      - name: Download sorry manifests
-        uses: actions/download-artifact@v4
-        with:
-          name: sorry-manifests
-          path: sorry-manifests
-
-      - name: Compute sorry delta
-        run: python3 scripts/sorry-diff.py sorry-manifests/sorry-manifest-base.txt sorry-manifests/sorry-manifest.txt
-
-      - name: Post PR comment
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: sorry-delta
-          path: .sorry-delta-comment.md

--- a/.github/workflows/sorry-delta-comment.yml
+++ b/.github/workflows/sorry-delta-comment.yml
@@ -1,0 +1,49 @@
+name: Sorry Delta Comment
+# Posts the sorry-delta PR comment after the Lean Verification workflow
+# completes.  Because workflow_run always executes in the context of the
+# *base* repository, the GITHUB_TOKEN has write access even for fork PRs.
+
+on:
+  workflow_run:
+    workflows: ["Lean Verification"]
+    types: [completed]
+
+jobs:
+  comment:
+    name: Report Sorry Delta
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: scripts/
+
+      - name: Download sorry manifests
+        uses: actions/download-artifact@v4
+        with:
+          name: sorry-manifests
+          path: sorry-manifests
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR number
+        id: pr
+        run: echo "number=$(cat sorry-manifests/pr-number.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Compute sorry delta
+        run: python3 scripts/sorry-diff.py sorry-manifests/sorry-manifest-base.txt sorry-manifests/sorry-manifest.txt
+
+      - name: Post PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: sorry-delta
+          number: ${{ steps.pr.outputs.number }}
+          path: .sorry-delta-comment.md


### PR DESCRIPTION
This PR moves the sorry-delta PR comment posting from an inline job in `lean.yml` to a separate `sorry-delta-comment.yml` workflow triggered by `workflow_run`. Because `workflow_run` executes in the base repo context, the `GITHUB_TOKEN` has write access even for fork PRs. The PR number is passed via artifact so the comment targets the correct PR.

Closes #56
