### PR TITLE
Add links to the aeneas issues as comments with the tweaks

### DIFF
--- a/aeneas-config.yml
+++ b/aeneas-config.yml
@@ -80,14 +80,17 @@ tweaks:
         set_option linter.style.whitespace false
 
     # Strip map field from Iterator instances (Aeneas generates it but Lean backend doesn't have it)
+    # https://github.com/AeneasVerif/aeneas/issues/1043
     - regex: "\\n  map := fun \\{B : Type\\} \\{F : Type\\}[\\s\\S]*?(?=\\n  enumerate)"
       replace: ""
 
     # Replace collect field with take := sorry in Iterator instances
+    # https://github.com/AeneasVerif/aeneas/issues/1043
     - regex: "\\n  collect := fun \\{B : Type\\}[\\s\\S]*?(?=\\n\\})"
       replace: "\n  take := sorry"
 
     # Sorry loop bodies where Aeneas generates () instead of the correct typed value
+    # https://github.com/AeneasVerif/aeneas/issues/1044
     - regex: "(def (?:encoding\\.gf\\.parallel_mult_loop\\.body|encoding\\.polynomial\\.lagrange_polys_for_complete_points_loop0\\.body|encoding\\.polynomial\\.PolyEncoder\\.from_pb_loop1\\.body|encoding\\.polynomial\\.PolyEncoder\\.encode_bytes_base_loop\\.body)\\n[\\s\\S]*?):= do[\\s\\S]*?(?=\\n/-- )"
       replace: "$1:= sorry"
 
@@ -100,6 +103,7 @@ tweaks:
       replace: "$1:= sorry"
 
     # Fix ok_or none type inference
+    # https://github.com/AeneasVerif/aeneas/issues/1018
     - find: "core.option.Option.ok_or none Error.StateDecode"
       replace: "core.option.Option.ok_or (none : Option _) Error.StateDecode"
     - regex: "(\\| core\\.ops\\.control_flow\\.ControlFlow\\.Continue) val2 (=>\\n\\s+let \\S+ ← encoding\\.polynomial\\.PolyDecoder\\.from_pb val2)"

--- a/aeneas-config.yml
+++ b/aeneas-config.yml
@@ -95,10 +95,12 @@ tweaks:
       replace: "$1:= sorry"
 
     # Sorry merge closure FnOnce call_once assignments (Aeneas types them wrong)
+    # https://github.com/AeneasVerif/aeneas/issues/1046
     - regex: "call_once :=\\n    proto\\.pq_ratchet\\.\\S+\\.merge\\.closure\\S*\\.Insts\\.CoreOpsFunctionFnOnceTupleTupleTuple\\.call_once\\n    bytesbufbuf_implBufInst\\n}"
       replace: "call_once := sorry\n}"
 
     # Sorry merge function bodies (broken Result.map with mistyped closures)
+    # https://github.com/AeneasVerif/aeneas/issues/1046
     - regex: "(def proto\\.pq_ratchet\\.(?:pq_ratchet_state\\.Inner|v1_msg\\.InnerMsg|v1_state\\.InnerState)\\.merge\\n[\\s\\S]*?):= do[\\s\\S]*?(?=\\n/-- )"
       replace: "$1:= sorry"
 


### PR DESCRIPTION
Adds links in the comments in aeneas-config.yml to document the reason for the current tweaks and to clarify how we can unfold the tweaks when the issues are solved upstream.

closes #54
