### PR TITLE
Fix Batteries lint errors in hand-written Lean files

### DIFF
--- a/Spqr/Math/Gf16/Field.lean
+++ b/Spqr/Math/Gf16/Field.lean
@@ -27,6 +27,7 @@ projects working with the same Galois field.
 
 open Polynomial
 
+/-- The Galois field GF(2^16), used as the coefficient field for SPQR polynomial encoding. -/
 abbrev GF216 := GaloisField 2 16
 
 namespace spqr.math.gf

--- a/Spqr/Specs/Encoding/Gf/GF16/ONE.lean
+++ b/Spqr/Specs/Encoding/Gf/GF16/ONE.lean
@@ -32,7 +32,6 @@ namespace spqr.encoding.gf.GF16
 theorem ONE_value : (ONE).value = 1#u16 := by
   simp [ONE]
 
-@[simp]
 theorem ONE_value_val : (ONE).value.val = 1 := by
   simp [ONE]
 

--- a/Spqr/Specs/Encoding/Gf/GF16/ZERO.lean
+++ b/Spqr/Specs/Encoding/Gf/GF16/ZERO.lean
@@ -33,7 +33,6 @@ namespace spqr.encoding.gf.GF16
 theorem ZERO_value : (ZERO).value = 0#u16 := by
   simp [ZERO]
 
-@[simp]
 theorem ZERO_value_val : (ZERO).value.val = 0 := by
   simp [ZERO]
 

--- a/Spqr/Specs/Encoding/Gf/Reduce/PolyReduce.lean
+++ b/Spqr/Specs/Encoding/Gf/Reduce/PolyReduce.lean
@@ -91,6 +91,7 @@ open Aeneas Aeneas.Std Result Polynomial spqr.encoding.gf.unaccelerated spqr.mat
 
 namespace spqr.encoding.gf.reduce
 
+/-- Reduce a 32-bit value modulo the GF(2^16) irreducible polynomial using the lookup table. -/
 def polyReduce (v : Nat) : Nat :=
   let t1 := reduceByteTable (v >>> 24)
   let v1 := v ^^^ (t1 <<< 8)


### PR DESCRIPTION
This PR:
- adds missing doc strings for `GF216` and `polyReduce`
- removes redundant `@[simp]` from `ONE_value_val` and `ZERO_value_val` (simp can already prove these from `ONE_value`/`ZERO_value`)

so that we have a green Batteries `runLinter`.

## Test plan

- [x] `lake build` succeeds locally
- [x] CI passes

closes https://github.com/Beneficial-AI-Foundation/SparsePostQuantumRatchet-verify/issues/82

Made with [Cursor](https://cursor.com)