### PR TITLE
CI: fail on non-sorry warnings and lint errors in hand-written code

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -31,13 +31,31 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Build Lean project
+      - name: Setup Lean
         uses: leanprover/lean-action@v1
         with:
-          build: true
+          build: false
           test: false
           lint: false
           use-mathlib-cache: true
+
+      - name: Build and check for non-sorry warnings
+        run: |
+          lake build --no-ansi 2>&1 | tee /tmp/lake-build.log
+          if grep 'warning:' /tmp/lake-build.log | grep -qv 'declaration uses .sorry'; then
+            echo "::error::Build produced warnings (other than sorry). Please fix them."
+            grep 'warning:' /tmp/lake-build.log | grep -v 'declaration uses .sorry'
+            exit 1
+          fi
+
+      - name: Lint hand-written code
+        run: |
+          lake exe runLinter Spqr 2>&1 | tee /tmp/lake-lint.log || true
+          if grep 'error:' /tmp/lake-lint.log | grep -qv 'Spqr/Code/'; then
+            echo "::error::Lint errors in hand-written code. Please fix them."
+            grep 'error:' /tmp/lake-lint.log | grep -v 'Spqr/Code/'
+            exit 1
+          fi
 
       - name: Restore base sorry manifest
         if: github.event_name == 'pull_request'

--- a/scripts/check-lint.sh
+++ b/scripts/check-lint.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== Build warning check ==="
+lake build --no-ansi 2>&1 | tee /tmp/lake-build.log
+if grep 'warning:' /tmp/lake-build.log | grep -qv 'declaration uses .sorry'; then
+  echo "FAIL: non-sorry warnings found:"
+  grep 'warning:' /tmp/lake-build.log | grep -v 'declaration uses .sorry'
+  exit 1
+fi
+echo "PASS"
+
+echo "=== Lint check ==="
+lake exe runLinter Spqr 2>&1 | tee /tmp/lake-lint.log || true
+if grep 'error:' /tmp/lake-lint.log | grep -qv 'Spqr/Code/'; then
+  echo "FAIL: lint errors in hand-written code:"
+  grep 'error:' /tmp/lake-lint.log | grep -v 'Spqr/Code/'
+  exit 1
+fi
+echo "PASS"


### PR DESCRIPTION
This PR:
- splits `lean-action` into setup-only step (`build: false`) and a custom `lake build` step that captures output for warning analysis
- adds **Build and check for non-sorry warnings** step: fails CI if any warnings other than `declaration uses 'sorry'` are found
- adds **Lint hand-written code** step: runs Batteries `runLinter` and fails CI on lint errors outside `Spqr/Code/` (Aeneas-generated files)
- adds `scripts/check-lint.sh` for local pre-push validation

Depends on #80 (lint fixes must be merged first or this PR's lint step will fail)

closes #77 

Made with [Cursor](https://cursor.com)