### PR TITLE
CI: deduplicate Lean Verification runs on PR branches

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -4,14 +4,17 @@ name: Lean Verification
 
 on:
   push:
-    branches: [ '**' ]
+    branches: [ 'main' ]
     paths:
       - 'Spqr/**'
       - 'lakefile.toml'
       - 'lean-toolchain'
       - '.github/workflows/lean.yml'
-  # since it is required for merging, it must run on each PR even if the files affected aren't in paths
-  # see https://docs.github.com/en/enterprise-cloud@latest/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+  # Since the check is required for merging, it must run on every PR even
+  # when no Lean-related files changed (GitHub treats a skipped required
+  # check as "not passed").  Restricting `push` to main avoids duplicate
+  # runs on PR branches while keeping the sorry-manifest cache working.
+  # See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
   pull_request: 
     branches: [ '**' ]
   workflow_dispatch:


### PR DESCRIPTION
This PR:
- restricts the `push` trigger in `lean.yml` to `main` only, so that pushes to PR branches no longer fire both `push` and `pull_request` runs of the same workflow
- keeps the `pull_request` trigger (which already covers all PRs) and the `push`-on-main path (needed for the sorry-manifest cache save step)

## Test plan

- [x] verify that this PR itself only triggers a single Lean Verification run (not two)
- [x] confirm sorry-manifest cache save still works on main merges (guarded by `github.event_name == 'push' && github.ref == 'refs/heads/main'`)

closes #83

Made with [Cursor](https://cursor.com)