### PR TITLE
CI: deduplicate Aeneas extraction runs on PR branches

### DIFF
--- a/.github/workflows/aeneas.yml
+++ b/.github/workflows/aeneas.yml
@@ -3,14 +3,18 @@
 name: Aeneas extraction
 on:
   push:
-    branches: [ '**' ]
+    branches: [ 'main' ]
     paths:
       - 'Spqr/**'
       - 'lakefile.toml'
       - 'lean-toolchain'
-      - '.github/workflows/lean.yml'
-  # since it is required for merging, it must run on each PR even if the files affected aren't in paths
-  # see https://docs.github.com/en/enterprise-cloud@latest/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+      - '.github/workflows/aeneas.yml'
+      - 'aeneas-config.yml'
+  # Since the check is required for merging, it must run on every PR even
+  # when no relevant files changed (GitHub treats a skipped required check
+  # as "not passed").  Restricting `push` to main avoids duplicate runs on
+  # PR branches.
+  # See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
   pull_request: 
     branches: [ '**' ]
   workflow_dispatch:


### PR DESCRIPTION
This PR:
- restricts the `push` trigger in `aeneas.yml` to `main` only, so that pushes to PR branches no longer fire both `push` and `pull_request` runs of the same workflow
- fixes the `paths` filter: it was referencing `.github/workflows/lean.yml` instead of `.github/workflows/aeneas.yml`, and was missing `aeneas-config.yml`

## Test plan

- [x] verify that this PR itself only triggers a single Aeneas extraction run (not two)

closes #85

Made with [Cursor](https://cursor.com)