### PR TITLE
test: verify CI lint warning gate

### DIFF
--- a/Spqr/Code/Types.lean
+++ b/Spqr/Code/Types.lean
@@ -1298,4 +1298,10 @@ structure v1.chunked.states.Recv where
   key : Option EpochSecret
   state : v1.chunked.states.States
 
+-- CI TEST: intentional warning in generated code to verify warning gate behavior
+set_option linter.unusedVariables true in
+def _testGenCodeWarning : Nat :=
+  let unusedInGenCode := 42
+  0
+
 end spqr

--- a/Spqr/Code/Types.lean
+++ b/Spqr/Code/Types.lean
@@ -1298,10 +1298,4 @@ structure v1.chunked.states.Recv where
   key : Option EpochSecret
   state : v1.chunked.states.States
 
--- CI TEST: intentional warning in generated code to verify warning gate behavior
-set_option linter.unusedVariables true in
-def _testGenCodeWarning : Nat :=
-  let unusedInGenCode := 42
-  0
-
 end spqr

--- a/Spqr/Math/Gf16/Basic.lean
+++ b/Spqr/Math/Gf16/Basic.lean
@@ -74,4 +74,9 @@ lemma polyGF2_modByMonic_idem (p : BinaryPoly) :
   Polynomial.modByMonic_eq_of_dvd_sub polyGF2_monic
     (polyGF2_dvd_modByMonic_sub p)
 
+-- CI TEST 4c: unused variable warning in Math/Gf16/Basic.lean
+def _testMultiWarning3 : Nat :=
+  let unused3 := 7
+  0
+
 end spqr.math.gf

--- a/Spqr/Specs/Encoding/Gf/GF16/ONE.lean
+++ b/Spqr/Specs/Encoding/Gf/GF16/ONE.lean
@@ -57,4 +57,9 @@ theorem ONE_spec :
       result.toGF216 = 1 ⦄ := by
   simp [GF16.toGF216, Nat.toGF216, natToBinaryPoly_one]
 
+-- CI TEST 4b: unused variable warning in ONE.lean
+def _testMultiWarning2 : Nat :=
+  let unused2 := 99
+  0
+
 end spqr.encoding.gf.GF16

--- a/Spqr/Specs/Encoding/Gf/GF16/ZERO.lean
+++ b/Spqr/Specs/Encoding/Gf/GF16/ZERO.lean
@@ -60,9 +60,4 @@ theorem ZERO_spec :
       (result.toGF216 : GF216) = 0 ⦄ := by
   simp [GF16.toGF216, Nat.toGF216, natToBinaryPoly_zero]
 
--- Intentional unused-variable warning to test CI lint gate (remove after test)
-def _testCILintGate : Nat :=
-  let unusedBinding := 42
-  0
-
 end spqr.encoding.gf.GF16

--- a/Spqr/Specs/Encoding/Gf/GF16/ZERO.lean
+++ b/Spqr/Specs/Encoding/Gf/GF16/ZERO.lean
@@ -60,4 +60,9 @@ theorem ZERO_spec :
       (result.toGF216 : GF216) = 0 ⦄ := by
   simp [GF16.toGF216, Nat.toGF216, natToBinaryPoly_zero]
 
+-- Intentional unused-variable warning to test CI lint gate (remove after test)
+def _testCILintGate : Nat :=
+  let unusedBinding := 42
+  0
+
 end spqr.encoding.gf.GF16

--- a/Spqr/Specs/Encoding/Gf/GF16/ZERO.lean
+++ b/Spqr/Specs/Encoding/Gf/GF16/ZERO.lean
@@ -60,4 +60,7 @@ theorem ZERO_spec :
       (result.toGF216 : GF216) = 0 ⦄ := by
   simp [GF16.toGF216, Nat.toGF216, natToBinaryPoly_zero]
 
+-- CI TEST 3: sorry warning should be allowed through the warning gate
+theorem _testSorryAllowed : (1 : Nat) = 1 := by sorry
+
 end spqr.encoding.gf.GF16

--- a/Spqr/Specs/Encoding/Gf/GF16/ZERO.lean
+++ b/Spqr/Specs/Encoding/Gf/GF16/ZERO.lean
@@ -60,7 +60,9 @@ theorem ZERO_spec :
       (result.toGF216 : GF216) = 0 ⦄ := by
   simp [GF16.toGF216, Nat.toGF216, natToBinaryPoly_zero]
 
--- CI TEST 3: sorry warning should be allowed through the warning gate
-theorem _testSorryAllowed : (1 : Nat) = 1 := by sorry
+-- CI TEST 4a: unused variable warning in ZERO.lean
+def _testMultiWarning1 : Nat :=
+  let unused1 := 42
+  0
 
 end spqr.encoding.gf.GF16


### PR DESCRIPTION
## Summary

- Introduces an intentional unused-variable warning in `Spqr/Specs/Encoding/Gf/GF16/ZERO.lean` to verify that the CI lint gate from #81 correctly catches and fails on non-sorry warnings.

## Expected outcome

The **"Build and check for non-sorry warnings"** step in the Lean Verification workflow should **fail** with a message about the unused variable `unusedBinding`.

## Cleanup

Close/delete this PR after confirming the CI gate works as expected.

Made with [Cursor](https://cursor.com)