### PR TITLE
CI: harden sorry manifest cache with restore-keys fallback

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -65,6 +65,8 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           key: sorry-manifest-${{ github.event.pull_request.base.ref }}-${{ github.event.pull_request.base.sha }}
+          restore-keys: |
+            sorry-manifest-${{ github.event.pull_request.base.ref }}-
           path: sorry-manifest.txt
 
       - name: Prepare base manifest
@@ -76,7 +78,9 @@ jobs:
         run: lake env lean scripts/Audit.lean
 
       - name: Save sorry manifest to cache
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: >-
+          github.ref == 'refs/heads/main' &&
+          (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: actions/cache/save@v4
         with:
           key: sorry-manifest-main-${{ github.sha }}


### PR DESCRIPTION
This PR:
- allows `workflow_dispatch` to save the sorry manifest cache (previously only `push` events could save)
- adds `restore-keys` prefix fallback to the cache restore step so it uses the most recent available manifest when an exact SHA match isn't available

Context:

The sorry manifest caching added in #81 works correctly under normal
conditions (each merge to main triggers a Lean workflow run that saves
the cache). However, when two PRs are merged in quick succession,
GitHub may deduplicate push events, skipping the Lean run for one of
them. If that skipped run was the one that would have saved the cache,
subsequent PRs can't compute a sorry delta.

These two changes make the caching resilient to such gaps:
1. `restore-keys` falls back to the most recent available manifest
   from the base branch instead of requiring an exact SHA match
2. `workflow_dispatch` can also save the cache, allowing manual
   re-seeding when needed