### PR TITLE
Specify and verify : `spqr::util::is_non_zero` in `util.rs`

### DIFF
--- a/Spqr.lean
+++ b/Spqr.lean
@@ -43,3 +43,4 @@ import Spqr.Specs.Encoding.Polynomial.Poly.Zero
 import Spqr.Specs.Encoding.Polynomial.Pt.Deserialize
 import Spqr.Specs.Encoding.Polynomial.Pt.Serialize
 import Spqr.Specs.Util.Inz
+import Spqr.Specs.Util.IsNonZero

--- a/Spqr/Code/FunsExternal.lean
+++ b/Spqr/Code/FunsExternal.lean
@@ -72,7 +72,16 @@ axiom Shared0T.Insts.CoreFmtDisplay.fmt
     Source: '/rustc/library/core/src/hint.rs', lines 490:0-490:40
     Name pattern: [core::hint::black_box] -/
 @[rust_fun "core::hint::black_box"]
-axiom core.hint.black_box {T : Type} : T → Result T
+def core.hint.black_box {T : Type} : T → Result T :=
+  fun x => ok x
+
+/-- **Spec theorem for `core::hint::black_box`**: `black_box` is documented as
+an identity function on values; its compile-time effect in Rust is making its
+argument opaque to the optimiser, which has no semantic content in the Lean model. -/
+@[step]
+theorem core.hint.black_box_spec {T : Type} (x : T) :
+    core.hint.black_box x ⦃ (r : T) => r = x ⦄ := by
+  simp [core.hint.black_box]
 
 /-- [core::iter::adapters::enumerate::{core::iter::traits::iterator::Iterator<(usize, Clause0_Item)> for core::iter::adapters::enumerate::Enumerate<I>}::next]:
     Source: '/rustc/library/core/src/iter/adapters/enumerate.rs', lines 79:4-79:64

--- a/Spqr/Specs/Util/IsNonZero.lean
+++ b/Spqr/Specs/Util/IsNonZero.lean
@@ -1,0 +1,36 @@
+/-
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Markus Dablander
+-/
+import Spqr.Code.Funs
+import Spqr.Specs.Util.Inz
+
+/-!
+# Spec theorem for `spqr::util::is_non_zero`
+
+Constant-time-firewalled wrapper around `inz`: applies `core::hint::black_box`
+to the result of `inz value` and is marked `#[inline(never)]` so the compiler
+cannot optimize the branchless indicator computation back into a data-dependent
+branch. Semantically, this is the identity on top of `inz`, so the spec asserts
+the same indicator semantics as `inz`: the result equals `1` when the input
+byte is non-zero, and `0` when it is zero.
+
+**Source:** "spqr/src/util.rs"
+-/
+
+open Aeneas Aeneas.Std
+namespace spqr.util
+
+/-- **Spec theorem for `spqr::util::is_non_zero`**
+• The function never panics (total function, no preconditions).
+• The result equals `1` when `value.val ≠ 0` and `0` when `value.val = 0`.
+-/
+@[step]
+theorem is_non_zero_spec (value : U8) :
+    is_non_zero value ⦃ (result : U8) =>
+      result.val = if value.val = 0 then 0 else 1 ⦄ := by
+  unfold is_non_zero
+  step*
+
+end spqr.util


### PR DESCRIPTION
This PR specifies and verifies `spqr::util::is_non_zero` in `util.rs`.

Verifying this spec theorem requires a usable model of`core::hint::black_box`, which was previously declared as an axiom. This PR therefore also replaces the `core.hint.black_box` axiom in `FunsExternal.lean` with an appropriate definition and an associated spec theorem.

Closes #158