### PR TITLE
build(lean): add SrcTranslated to defaultTargets

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -15,7 +15,7 @@ on:
   # check as "not passed").  Restricting `push` to main avoids duplicate
   # runs on PR branches while keeping the sorry-manifest cache working.
   # See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
-  pull_request: 
+  pull_request:
     branches: [ '**' ]
   workflow_dispatch:
 
@@ -53,6 +53,7 @@ jobs:
 
       - name: Lint hand-written code
         run: |
+          # Lint ONLY the hand-written `Spqr` library.
           lake exe runLinter Spqr 2>&1 | tee /tmp/lake-lint.log || true
           if grep -q 'error:' /tmp/lake-lint.log; then
             echo "::error::Lint errors in hand-written code. Please fix them."

--- a/doc/WORKFLOW_AND_PR_GUIDE.md
+++ b/doc/WORKFLOW_AND_PR_GUIDE.md
@@ -18,6 +18,10 @@ lake exe mk_all
 
 to regenerate the root import file that lists every module in the project.
 
+## Linting
+
+To lint the Lean code, use `lake exe runLinter Spqr`.
+
 ## PR Workflow and Formatting
 
 All PRs, unless special circumstances are justified, must close an open issue in the project.
@@ -64,8 +68,4 @@ See our performance tracking guidelines for more information: [TODO #11: write, 
 
 **Specifications:** PRs introducing AI-generated specifications of any kind are strictly prohibited, and their submission may result in a contribution ban at the maintainers' discretion.
 
-**Proofs:** AI-generated proofs are welcome, as long as they are compliant with the style guide and requirements listed in this document. The human submitting the PR is held responsible for the contents of the PR, in particular its adherence to style and contribution guidelines, as well as the performance impact outlined above. 
-
-
-
-
+**Proofs:** AI-generated proofs are welcome, as long as they are compliant with the style guide and requirements listed in this document. The human submitting the PR is held responsible for the contents of the PR, in particular its adherence to style and contribution guidelines, as well as the performance impact outlined above.

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,6 +1,6 @@
 name = "Spqr"
 version = "0.1.0"
-defaultTargets = ["Spqr"]
+defaultTargets = ["Spqr", "SrcTranslated"]
 
 [leanOptions]
 autoImplicit = false


### PR DESCRIPTION
Closes #202

This PR adds "SrcTranslated" to defaultTargets. This enables `probe-lean extract` to generate deps for srcTranslated as well.
