### PR TITLE
Import spec-indent linter, fix it, and clean up warnings

### DIFF
--- a/Spqr.lean
+++ b/Spqr.lean
@@ -1,5 +1,7 @@
 import Spqr.Aux.Aeneas.StdNextCoreIterRangeStep
 import Spqr.Aux.Aeneas.StdNextStepUsize
+import Spqr.Lint.Basic
+import Spqr.Lint.SpecIndent
 import Spqr.Math.Gf16.Basic
 import Spqr.Math.Gf16.Field
 import Spqr.Math.Gf16.Irreducible

--- a/Spqr/Lint/Basic.lean
+++ b/Spqr/Lint/Basic.lean
@@ -1,0 +1,24 @@
+/-
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Liao Zhang
+-/
+import Spqr.Lint.SpecIndent
+
+/-!
+# Curve25519Dalek project linters
+
+Importing this module activates all project-specific linters.  It is imported transitively
+by `Curve25519Dalek.Aux` and `Curve25519Dalek.FunsExternal`, which together cover the full
+transitive import graph of spec theorem files.
+
+## Linters provided
+
+| Option | What it checks |
+|---|---|
+| `linter.curve25519.specIndent` | `@[step]` theorem indentation (binders/type/body/proof) |
+
+All linters are enabled by default (`defValue := true`) and can be suppressed locally with a
+documented `set_option linter.curve25519.* false in` — consistent with the style guide's
+requirement that suppressions carry an explanatory comment.
+-/

--- a/Spqr/Lint/Basic.lean
+++ b/Spqr/Lint/Basic.lean
@@ -6,19 +6,19 @@ Authors: Liao Zhang
 import Spqr.Lint.SpecIndent
 
 /-!
-# Curve25519Dalek project linters
+# SparsePostQuantumRatchet verification project linters
 
 Importing this module activates all project-specific linters.  It is imported transitively
-by `Curve25519Dalek.Aux` and `Curve25519Dalek.FunsExternal`, which together cover the full
-transitive import graph of spec theorem files.
+by `SrcTranslated.TypesExternal` (and hence `SrcTranslated.FunsExternal`), which together
+cover the full transitive import graph of spec theorem files.
 
 ## Linters provided
 
 | Option | What it checks |
 |---|---|
-| `linter.curve25519.specIndent` | `@[step]` theorem indentation (binders/type/body/proof) |
+| `linter.spqr.specIndent` | `@[step]` theorem indentation (binders/type/body/proof) |
 
 All linters are enabled by default (`defValue := true`) and can be suppressed locally with a
-documented `set_option linter.curve25519.* false in` — consistent with the style guide's
+documented `set_option linter.spqr.* false in` — consistent with the style guide's
 requirement that suppressions carry an explanatory comment.
 -/

--- a/Spqr/Lint/SpecIndent.lean
+++ b/Spqr/Lint/SpecIndent.lean
@@ -1,0 +1,239 @@
+/-
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Liao Zhang
+-/
+import Lean
+import Mathlib.Tactic.Linter
+
+/-!
+# Linter: `specIndent` — spec theorem indentation style
+
+Enforces the four indentation rules defined in `doc/STYLE_GUIDE.md`:
+
+| Location | Expected column (0-indexed) | Scope |
+|---|---|---|
+| Continuation line on a new line after the `theorem` line | 4 | `@[step]` only |
+| Postcondition body on a new line after `=>` in the WP binder | 6 | `@[step]` only |
+| `∧` RHS postcondition on a new line inside the WP binder | 6 | `@[step]` only |
+| Proof body after `by` (when on a new line) | 2 | all theorems |
+
+The first three checks apply only to `@[step]` Aeneas spec theorems; the proof-body indent
+rule applies to every theorem so that the project's 2-space proof style is uniform.  The
+linter is controlled by a single option `linter.curve25519.specIndent` so that a justified
+deviation can be suppressed uniformly.
+-/
+
+namespace Curve25519Dalek.Lint
+
+open Lean Elab Command Linter
+
+/-! ## Option -/
+
+/-- Warns when a theorem's indentation deviates from the project style guide.
+See `doc/STYLE_GUIDE.md` §"Indentation Structure". -/
+register_option linter.curve25519.specIndent : Bool := {
+  defValue := true
+  descr := "Warns when a theorem's indentation deviates from the style guide."
+}
+
+/-! ## Helpers -/
+
+/-- Return `true` when the declaration command `stx` carries an `@[step]` attribute.
+Only inspects `declModifiers` (`stx[0]`) to avoid false positives from proof bodies. -/
+private def hasStepAttr (stx : Syntax) : Bool :=
+  match stx.getArgs[0]? with
+  | none      => false
+  | some mods => mods.find? (fun s => s.isIdent && s.getId == `step) |>.isSome
+
+/-- 0-indexed column of `stx`'s leading source position. -/
+private def colOf (stx : Syntax) (fm : FileMap) : Option Nat :=
+  stx.getPos? >>= fun p => some (fm.toPosition p).column
+
+/-- 1-indexed source line of `stx`'s leading position. -/
+private def lineOf (stx : Syntax) (fm : FileMap) : Option Nat :=
+  stx.getPos? >>= fun p => some (fm.toPosition p).line
+
+/-- 1-indexed source line of `stx`'s trailing (end) position. -/
+private def tailLineOf (stx : Syntax) (fm : FileMap) : Option Nat :=
+  stx.getTailPos? >>= fun p => some (fm.toPosition p).line
+
+/-- `true` iff `stx` is a `A ∧ B` node (the `«term_∧_»` notation).
+Matches by checking that the node has exactly three children and the middle child is the
+`∧` atom.  We use the atom-value check rather than `stx.getKind == \`«term_∧_»` to stay
+independent of namespace resolution details. -/
+private def isAndNode (stx : Syntax) : Bool :=
+  stx.getArgs.size == 3 &&
+  match stx.getArgs[1]? with
+  | some (Syntax.atom _ v) => v.trimAscii == "∧"
+  | _                      => false
+
+/-- Recursively collect every WP-binder body — the term immediately after `=>` in
+`⦃ binder => body ⦄` — that starts on a new line after `=>` and is NOT at `expected` column. -/
+private partial def collectMisindentedWpBodies
+    (stx : Syntax) (fm : FileMap) (expected : Nat) : Array Syntax :=
+  let childResults := stx.getArgs.flatMap (collectMisindentedWpBodies · fm expected)
+  let args := stx.getArgs
+  -- Only match nodes that have ` ⦃ ` as a direct atom child (WP binder notation).
+  let hasLLBracket := args.any fun c =>
+    match c with | Syntax.atom _ v => v.trimAscii == "⦃" | _ => false
+  if !hasLLBracket then childResults
+  else
+    match args.findIdx? (fun c =>
+    match c with | Syntax.atom _ v => v.trimAscii == "=>" | _ => false) with
+    | none => childResults
+    | some arrowIdx =>
+      match args[arrowIdx]?, args[arrowIdx + 1]? with
+      | some arrowAtom, some body =>
+        match lineOf arrowAtom fm, lineOf body fm, colOf body fm with
+        | some arrowLine, some bodyLine, some bodyCol =>
+          if bodyLine > arrowLine && bodyCol ≠ expected then childResults.push body
+          else childResults
+        | _, _, _ => childResults
+      | _, _ => childResults
+
+/-- Recursively collect every WP-binder body term (the `body` in `⦃ binder => body ⦄`).
+Used to scope `∧`-RHS checks to postconditions only. -/
+private partial def collectWpBodies (stx : Syntax) : Array Syntax :=
+  let args := stx.getArgs
+  let hasLLBracket := args.any fun c =>
+    match c with | Syntax.atom _ v => v.trimAscii == "⦃" | _ => false
+  if !hasLLBracket then args.flatMap collectWpBodies
+  else
+    match args.findIdx? (fun c =>
+      match c with | Syntax.atom _ v => v.trimAscii == "=>" | _ => false) with
+      | none     => #[]
+      | some idx => match args[idx + 1]? with
+        | some body => #[body]
+        | none      => #[]
+
+
+private partial def collectMisindentedAndRhs_aux
+    (stx : Syntax) (fm : FileMap) (expected : Nat) : Array (Syntax × String) :=
+  if isAndNode stx then
+    match stx.getArgs[0]?, stx.getArgs[1]?, stx.getArgs[2]? with
+    | some lhs, some andNode, some rhs =>
+        let acc := collectMisindentedAndRhs_aux rhs fm expected
+        match tailLineOf lhs fm, lineOf andNode fm, lineOf rhs fm, colOf rhs fm with
+        | some lhsTailLine, some andLine, some rhsLine, some rhsCol =>
+          let acc :=
+            if andLine > lhsTailLine then
+              acc.push (andNode,
+                "∧ operator should be appended to the end of the preceding line, \
+                not placed at the start of a new line, \
+                per the spec theorem style guide.")
+            else acc
+          let acc :=
+            if rhsLine > andLine && rhsCol ≠ expected then
+              acc.push (rhs,
+                s!"Postcondition conjunct is at column {rhsCol}, expected {expected}. \
+                Conjunction operands on new lines should be indented {expected} spaces \
+                per the spec theorem style guide.")
+            else acc
+          acc
+        | _, _, _, _ => acc
+    | _, _, _ => #[]
+  else #[]
+
+
+private partial def collectMisindentedAndRhs
+    (stx : Syntax) (fm : FileMap) (expected : Nat) : Array (Syntax × String) :=
+  if isAndNode stx then
+    collectMisindentedAndRhs_aux stx fm expected
+  else
+    stx.getArgs.flatMap (collectMisindentedAndRhs · fm expected)
+
+
+/-! ## Linter -/
+
+/-- `@[step]`-gated checks: continuation lines (col 4), postcondition body (col 6),
+and `∧` RHS (col 6).  Runs only when the theorem carries `@[step]`. -/
+private def runStepChecks
+    (inner : Syntax) (bindersNode typeTerm : Syntax) (kwLine : Nat) (fm : FileMap)
+    : CommandElabM Unit := do
+  let _ := inner
+  -- ── Check 1: Continuation lines at column 4 ─────────────────────────────
+  -- Arguments, preconditions, and the function application line all share the
+  -- same 4-space rule.  Keep only the first node on each continuation line so
+  -- that multiple binders sharing a line (e.g. `(n : Nat) (_h : n > 0)`) count
+  -- as one logical line.
+  let (firstPerLine, _) := (bindersNode.getArgs ++ #[typeTerm]).foldl
+    (fun acc node =>
+      let (arr, seen) := acc
+      match lineOf node fm with
+      | some l => if l > kwLine && !seen.contains l then (arr.push node, seen.cons l)
+                  else acc
+      | none   => acc)
+    ((#[] : Array Syntax), ([] : List Nat))
+  for node in firstPerLine do
+    if let some nodeCol := colOf node fm then
+      unless nodeCol == 4 do
+        logLint linter.curve25519.specIndent node
+          m!"Continuation line is at column {nodeCol}, expected 4. \
+            Arguments, preconditions, and the function application line \
+            on a new line should be indented 4 spaces \
+            per the spec theorem style guide."
+  -- ── Check 3a: First postcondition body at column 6 ──────────────────────
+  let misindentedBodies := collectMisindentedWpBodies typeTerm fm 6
+  for node in misindentedBodies do
+    let col := (colOf node fm).getD 0
+    logLint linter.curve25519.specIndent node
+      m!"Postcondition body is at column {col}, expected 6. \
+        The postcondition body after `=>` should be indented 6 spaces \
+        per the spec theorem style guide."
+  -- ── Check 3b: ∧ postcondition RHS at column 6 ────────────────────────────
+  -- Suppress 3b on any WP body that 3a already flagged: when the whole conjunctive
+  -- body is misindented, 3a's body warning already covers the mistake, so re-reporting
+  -- each conjunct would emit several messages for one block-level indentation slip.
+  let flaggedBodyPos := misindentedBodies.filterMap (·.getPos?)
+  for body in collectWpBodies typeTerm do
+    if (body.getPos?.map flaggedBodyPos.contains).getD false then continue
+    for (node, msg) in collectMisindentedAndRhs body fm 6 do
+      logLint linter.curve25519.specIndent node m!"{msg}"
+
+/-- Check 4 (applies to every theorem): proof body after `by` must be at column 2
+when it starts on a new line. -/
+private def runProofBodyCheck (declVal : Syntax) (fm : FileMap) : CommandElabM Unit := do
+  unless declVal.isOfKind ``Lean.Parser.Command.declValSimple do return
+  -- declValSimple[0]=":=", [1]=declBody, [2]=Termination.suffix, [3]=whereDecls
+  let some proofTerm := declVal.getArgs[1]? | return
+  unless proofTerm.isOfKind ``Lean.Parser.Term.byTactic do return
+  -- byTactic[0]="by ", [1]=tacticSeq
+  let some byKw      := proofTerm.getArgs[0]? | return
+  let some tacticSeq := proofTerm.getArgs[1]? | return
+  if let some byLine  := lineOf byKw fm then
+    if let some tacLine := lineOf tacticSeq fm then
+      if tacLine > byLine then
+        if let some tacCol := colOf tacticSeq fm then
+          unless tacCol == 2 do
+            logLint linter.curve25519.specIndent tacticSeq
+              m!"Proof body is at column {tacCol}, expected 2. \
+                Tactics after `by` should be indented 2 spaces \
+                per the project style guide."
+
+/-- Implementation of `linter.curve25519.specIndent`. -/
+def specIndentLinter : Linter where run stx := do
+  unless getLinterValue linter.curve25519.specIndent (← getLinterOptions) do return
+  unless stx.isOfKind ``Lean.Parser.Command.declaration do return
+  let some inner := stx.getArgs[1]? | return
+  unless inner.isOfKind ``Lean.Parser.Command.theorem do return
+  let fm ← getFileMap
+  -- ── Extract key sub-trees ─────────────────────────────────────────────────
+  let some kwNode  := inner.getArgs[0]? | return   -- "theorem" keyword
+  let some sig     := inner.getArgs[2]? | return   -- declSig
+  let some declVal := inner.getArgs[3]? | return   -- declVal
+  let some kwLine  := lineOf kwNode fm  | return
+  -- declSig[0] = binder array,  declSig[1] = typeSpec
+  let some bindersNode := sig.getArgs[0]? | return
+  let some typeSpec    := sig.getArgs[1]? | return
+  -- typeSpec[0] = ":" atom,  typeSpec[1] = type term
+  let some typeTerm  := typeSpec.getArgs[1]? | return
+  -- `@[step]`-gated structural checks (continuation lines, postcondition body, ∧ RHS).
+  if hasStepAttr stx then
+    runStepChecks inner bindersNode typeTerm kwLine fm
+  -- Universal proof-body indent check (applies to every theorem).
+  runProofBodyCheck declVal fm
+
+initialize addLinter specIndentLinter
+
+end Curve25519Dalek.Lint

--- a/Spqr/Lint/SpecIndent.lean
+++ b/Spqr/Lint/SpecIndent.lean
@@ -20,11 +20,11 @@ Enforces the four indentation rules defined in `doc/STYLE_GUIDE.md`:
 
 The first three checks apply only to `@[step]` Aeneas spec theorems; the proof-body indent
 rule applies to every theorem so that the project's 2-space proof style is uniform.  The
-linter is controlled by a single option `linter.curve25519.specIndent` so that a justified
+linter is controlled by a single option `linter.spqr.specIndent` so that a justified
 deviation can be suppressed uniformly.
 -/
 
-namespace Curve25519Dalek.Lint
+namespace Spqr.Lint
 
 open Lean Elab Command Linter
 
@@ -32,7 +32,7 @@ open Lean Elab Command Linter
 
 /-- Warns when a theorem's indentation deviates from the project style guide.
 See `doc/STYLE_GUIDE.md` §"Indentation Structure". -/
-register_option linter.curve25519.specIndent : Bool := {
+register_option linter.spqr.specIndent : Bool := {
   defValue := true
   descr := "Warns when a theorem's indentation deviates from the style guide."
 }
@@ -173,7 +173,7 @@ private def runStepChecks
   for node in firstPerLine do
     if let some nodeCol := colOf node fm then
       unless nodeCol == 4 do
-        logLint linter.curve25519.specIndent node
+        logLint linter.spqr.specIndent node
           m!"Continuation line is at column {nodeCol}, expected 4. \
             Arguments, preconditions, and the function application line \
             on a new line should be indented 4 spaces \
@@ -182,7 +182,7 @@ private def runStepChecks
   let misindentedBodies := collectMisindentedWpBodies typeTerm fm 6
   for node in misindentedBodies do
     let col := (colOf node fm).getD 0
-    logLint linter.curve25519.specIndent node
+    logLint linter.spqr.specIndent node
       m!"Postcondition body is at column {col}, expected 6. \
         The postcondition body after `=>` should be indented 6 spaces \
         per the spec theorem style guide."
@@ -194,7 +194,7 @@ private def runStepChecks
   for body in collectWpBodies typeTerm do
     if (body.getPos?.map flaggedBodyPos.contains).getD false then continue
     for (node, msg) in collectMisindentedAndRhs body fm 6 do
-      logLint linter.curve25519.specIndent node m!"{msg}"
+      logLint linter.spqr.specIndent node m!"{msg}"
 
 /-- Check 4 (applies to every theorem): proof body after `by` must be at column 2
 when it starts on a new line. -/
@@ -211,14 +211,14 @@ private def runProofBodyCheck (declVal : Syntax) (fm : FileMap) : CommandElabM U
       if tacLine > byLine then
         if let some tacCol := colOf tacticSeq fm then
           unless tacCol == 2 do
-            logLint linter.curve25519.specIndent tacticSeq
+            logLint linter.spqr.specIndent tacticSeq
               m!"Proof body is at column {tacCol}, expected 2. \
                 Tactics after `by` should be indented 2 spaces \
                 per the project style guide."
 
-/-- Implementation of `linter.curve25519.specIndent`. -/
+/-- Implementation of `linter.spqr.specIndent`. -/
 def specIndentLinter : Linter where run stx := do
-  unless getLinterValue linter.curve25519.specIndent (← getLinterOptions) do return
+  unless getLinterValue linter.spqr.specIndent (← getLinterOptions) do return
   unless stx.isOfKind ``Lean.Parser.Command.declaration do return
   let some inner := stx.getArgs[1]? | return
   unless inner.isOfKind ``Lean.Parser.Command.theorem do return
@@ -241,4 +241,4 @@ def specIndentLinter : Linter where run stx := do
 
 initialize addLinter specIndentLinter
 
-end Curve25519Dalek.Lint
+end Spqr.Lint

--- a/Spqr/Lint/SpecIndent.lean
+++ b/Spqr/Lint/SpecIndent.lean
@@ -15,7 +15,7 @@ Enforces the four indentation rules defined in `doc/STYLE_GUIDE.md`:
 |---|---|---|
 | Continuation line on a new line after the `theorem` line | 4 | `@[step]` only |
 | Postcondition body on a new line after `=>` in the WP binder | 6 | `@[step]` only |
-| `∧` RHS postcondition on a new line inside the WP binder | 6 | `@[step]` only |
+| `∧` RHS of the conjunction directly after the first `=>` of the WP binder | 6 | `@[step]` only |
 | Proof body after `by` (when on a new line) | 2 | all theorems |
 
 The first three checks apply only to `@[step]` Aeneas spec theorems; the proof-body indent
@@ -136,12 +136,17 @@ private partial def collectMisindentedAndRhs_aux
   else #[]
 
 
-private partial def collectMisindentedAndRhs
+/-- Check the conjunction that is *directly* the postcondition body — the term immediately
+after the first `=>` of the WP binder.  We deliberately do NOT recurse into sub-terms: when
+the body is some other form (e.g. a `match` whose arms each introduce their own `=>`), the
+conjuncts nested under those later arrows have their own natural indentation and must not be
+flagged.  The rule scopes to the indentation after the *first* `=>` only. -/
+private def collectMisindentedAndRhs
     (stx : Syntax) (fm : FileMap) (expected : Nat) : Array (Syntax × String) :=
   if isAndNode stx then
     collectMisindentedAndRhs_aux stx fm expected
   else
-    stx.getArgs.flatMap (collectMisindentedAndRhs · fm expected)
+    #[]
 
 
 /-! ## Linter -/

--- a/Spqr/Specs/Aeneas/IntoIteratorSlice.lean
+++ b/Spqr/Specs/Aeneas/IntoIteratorSlice.lean
@@ -42,10 +42,9 @@ The function always succeeds (no panic) for any `Slice T` input.
 -/
 @[step]
 theorem into_iter_spec {T : Type} (s : Slice T) :
-    SharedASlice.Insts.CoreIterTraitsCollectIntoIteratorSharedATIter.into_iter
-      s
-      ⦃ (iter : core.slice.iter.Iter T) =>
-        iter.slice = s ∧ iter.i = 0 ⦄ := by
+    SharedASlice.Insts.CoreIterTraitsCollectIntoIteratorSharedATIter.into_iter s ⦃
+      (iter : core.slice.iter.Iter T) =>
+      iter.slice = s ∧ iter.i = 0 ⦄ := by
   unfold SharedASlice.Insts.CoreIterTraitsCollectIntoIteratorSharedATIter.into_iter
   simp [WP.spec_ok]
 

--- a/Spqr/Specs/Aeneas/SliceIteratorNext.lean
+++ b/Spqr/Specs/Aeneas/SliceIteratorNext.lean
@@ -44,14 +44,13 @@ The slice iterator `next` always succeeds and either:
 @[step]
 theorem next_spec {T : Type}
     (iter : core.slice.iter.Iter T) :
-    core.slice.iter.IteratorSliceIter.next iter
-      ⦃ (opt, iter') =>
-        match opt with
-        | none => ¬ iter.i < iter.slice.len ∧ iter' = iter
-        | some _ =>
-            iter.i < iter.slice.len ∧
-            iter'.slice = iter.slice ∧
-            iter'.i = iter.i + 1 ⦄ := by
+    core.slice.iter.IteratorSliceIter.next iter ⦃ (opt, iter') =>
+      match opt with
+      | none => ¬ iter.i < iter.slice.len ∧ iter' = iter
+      | some _ =>
+          iter.i < iter.slice.len ∧
+          iter'.slice = iter.slice ∧
+          iter'.i = iter.i + 1 ⦄ := by
   suffices h : ∃ opt iter',
       core.slice.iter.IteratorSliceIter.next iter
         = ok (opt, iter') ∧

--- a/Spqr/Specs/Encoding/Polynomial/Poly/AddAssign.lean
+++ b/Spqr/Specs/Encoding/Polynomial/Poly/AddAssign.lean
@@ -228,8 +228,8 @@ theorem loop_spec
     (h_start : iter.iter.i = 0)
     (h_len : max self.degree other.length < Usize.max) :
     add_assign_loop iter self ⦃ (result : Poly) =>
-        result.degree = max self.degree other.length ∧
-        result.toGF216Poly = self.toGF216Poly + listToGF216Poly other ⦄ := by
+      result.degree = max self.degree other.length ∧
+      result.toGF216Poly = self.toGF216Poly + listToGF216Poly other ⦄ := by
   unfold add_assign_loop
   apply loop.spec_decr_nat
     (measure := fun (p : Enumerate (Iter GF16) × Poly) => p.1.iter.slice.length - p.1.iter.i)

--- a/Spqr/Specs/Encoding/Polynomial/Poly/LagrangeInterpolateComplete.lean
+++ b/Spqr/Specs/Encoding/Polynomial/Poly/LagrangeInterpolateComplete.lean
@@ -78,9 +78,9 @@ theorem loop0_spec
     (pi : Pt)
     (denominator : GF16) :
     lagrange_interpolate_complete_loop0 iter pi denominator ⦃ (result : Pt × GF16) =>
-        result.1 = pi ∧
-        result.2.toGF216 = denominator.toGF216 *
-          lagrangeDenomProd pi.x iter.slice.val iter.i ⦄ := by
+      result.1 = pi ∧
+      result.2.toGF216 = denominator.toGF216 *
+        lagrangeDenomProd pi.x iter.slice.val iter.i ⦄ := by
   unfold lagrange_interpolate_complete_loop0
   apply loop.spec_decr_nat
     (measure := fun (p : core.slice.iter.Iter Pt × GF16) =>
@@ -153,15 +153,14 @@ theorem loop1_spec
     (scale : spqr.encoding.gf.GF16)
     (h_start : iter.start.val = 1)
     (h_end : iter.«end».val = v.val.length) :
-    lagrange_interpolate_complete_loop1 iter v g scale
-      ⦃ (result : alloc.vec.Vec GF16) =>
-        result.val.length = v.val.length ∧
-        (∀ k (hk : k < result.val.length),
-          0 < k →
-            (result.val.get ⟨k, hk⟩).toGF216 =
-              scale.toGF216 * hornerAccum g v.val k) ∧
-        (∀ (h0 : 0 < result.val.length),
-        (result.val.get ⟨0, h0⟩).toGF216 = hornerAccum g v.val 0) ⦄ := by
+    lagrange_interpolate_complete_loop1 iter v g scale ⦃ (result : alloc.vec.Vec GF16) =>
+      result.val.length = v.val.length ∧
+      (∀ k (hk : k < result.val.length),
+        0 < k →
+          (result.val.get ⟨k, hk⟩).toGF216 =
+            scale.toGF216 * hornerAccum g v.val k) ∧
+      (∀ (h0 : 0 < result.val.length),
+      (result.val.get ⟨0, h0⟩).toGF216 = hornerAccum g v.val 0) ⦄ := by
   unfold lagrange_interpolate_complete_loop1
   apply loop.spec_decr_nat
     (measure := fun (p : core.ops.range.Range Std.Usize ×
@@ -238,11 +237,10 @@ theorem lagrange_interpolate_complete_spec
     (hi : i.val < pts.val.length)
     (hlen : 0 < self.coefficients.val.length)
     (heval : self.evalAt (pts.val.get ⟨i.val, hi⟩).x = 0) :
-    lagrange_interpolate_complete self pts i
-      ⦃ (result : Poly) =>
-        result.coefficients.val.length = self.coefficients.val.length ∧
-        result.toGF216Poly * (X - C (GF16.toGF216 (pts.val.get ⟨i.val, hi⟩).x)) =
-          X * C (lagrangeScaleGF216 (pts.val.get ⟨i.val, hi⟩) pts.val) * self.toGF216Poly ⦄ := by
+    lagrange_interpolate_complete self pts i ⦃ (result : Poly) =>
+      result.coefficients.val.length = self.coefficients.val.length ∧
+      result.toGF216Poly * (X - C (GF16.toGF216 (pts.val.get ⟨i.val, hi⟩).x)) =
+        X * C (lagrangeScaleGF216 (pts.val.get ⟨i.val, hi⟩) pts.val) * self.toGF216Poly ⦄ := by
   unfold lagrange_interpolate_complete
   step*
   · -- success path (b = true)

--- a/SrcTranslated/FunsExternal.lean
+++ b/SrcTranslated/FunsExternal.lean
@@ -232,7 +232,7 @@ def I32.Insts.CoreIterRangeStep.forward_checked
 @[step]
 private theorem I32_forward_checked_one_spec
     (start : I32) :
-     I32.Insts.CoreIterRangeStep.forward_checked start 1#usize ⦃ (opt : Option I32) =>
+    I32.Insts.CoreIterRangeStep.forward_checked start 1#usize ⦃ (opt : Option I32) =>
       match opt with
       | some z => start.val + 1 ≤ I32.max ∧ z.val = start.val + 1
       | none   => ¬ start.val + 1 ≤ I32.max ⦄ := by
@@ -661,7 +661,7 @@ theorem into_iter_spec {T : Type} (s : Slice T) :
     SharedASlice.Insts.CoreIterTraitsCollectIntoIteratorSharedATIter.into_iter
       s
       ⦃ (iter : core.slice.iter.Iter T) =>
-        iter.slice = s ∧ iter.i = 0 ⦄ := by
+      iter.slice = s ∧ iter.i = 0 ⦄ := by
   unfold SharedASlice.Insts.CoreIterTraitsCollectIntoIteratorSharedATIter.into_iter
   simp [WP.spec_ok]
 

--- a/SrcTranslated/TypesExternal.lean
+++ b/SrcTranslated/TypesExternal.lean
@@ -2,6 +2,7 @@
 -- [spqr]: external types.
 -- This is a template file: rename it to "TypesExternal.lean" and fill the holes.
 import Aeneas
+import Spqr.Lint.Basic
 open Aeneas Aeneas.Std Result ControlFlow Error
 set_option linter.dupNamespace false
 set_option linter.hashCommand false

--- a/Tests.lean
+++ b/Tests.lean
@@ -1,0 +1,1 @@
+import Tests.LinterTest.SpecIndent

--- a/Tests/LinterTest/SpecIndent.lean
+++ b/Tests/LinterTest/SpecIndent.lean
@@ -7,22 +7,22 @@ import Aeneas
 import Spqr.Lint.Basic
 
 /-!
-# Tests for `linter.curve25519.specIndent`
+# Tests for `linter.spqr.specIndent`
 
 Tests for the four indentation checks.  The first three checks fire only on `@[step]`
 theorems; the proof-body (Check 4) rule fires on every theorem.  Each `#guard_msgs` block
 targets exactly one violation so the expected-output annotation stays minimal.
 
 These tests live in the `Tests` Lake library (module `Tests.LinterTest.SpecIndent`) rather
-than in the `Curve25519Dalek` library, so the dummy theorems below (and their `@[step]`
+than in the `Spqr` library, so the dummy theorems below (and their `@[step]`
 registrations) never leak into the production library or its public namespace.  They are
-additionally wrapped in the `Curve25519Dalek.Lint.Test` namespace as a second line of
+additionally wrapped in the `Spqr.Lint.Test` namespace as a second line of
 defence.
 -/
 
 open Aeneas Aeneas.Std Result Aeneas.Std.WP
 
-namespace Curve25519Dalek.Lint.Test
+namespace Spqr.Lint.Test
 
 -- Two minimal dummy functions for the test cases below.
 private def dummyI (n : Nat) : Result Nat := .ok n
@@ -33,7 +33,7 @@ private def dummyP (n : Nat) : Result (Nat × Nat) := .ok ⟨n, n⟩
 /--
 warning: Continuation line is at column 2, expected 4. Arguments, preconditions, and the function application line on a new line should be indented 4 spaces per the spec theorem style guide.
 
-Note: This linter can be disabled with `set_option linter.curve25519.specIndent false`
+Note: This linter can be disabled with `set_option linter.spqr.specIndent false`
 -/
 #guard_msgs in
 -- Triggers `specIndent` check 1: `(_h : n > 0)` wraps to a new line but uses only 2 spaces.
@@ -59,7 +59,7 @@ theorem dummyI_binder_ok_spec (n : Nat) (_h
 /--
 warning: Continuation line is at column 2, expected 4. Arguments, preconditions, and the function application line on a new line should be indented 4 spaces per the spec theorem style guide.
 
-Note: This linter can be disabled with `set_option linter.curve25519.specIndent false`
+Note: This linter can be disabled with `set_option linter.spqr.specIndent false`
 -/
 #guard_msgs in
 -- Triggers `specIndent` check 1: type term is on a new line but only 2 spaces deep.
@@ -84,7 +84,7 @@ theorem dummyI_type_ok_spec (n : Nat) :
 /--
 warning: Postcondition body is at column 8, expected 6. The postcondition body after `=>` should be indented 6 spaces per the spec theorem style guide.
 
-Note: This linter can be disabled with `set_option linter.curve25519.specIndent false`
+Note: This linter can be disabled with `set_option linter.spqr.specIndent false`
 -/
 #guard_msgs in
 -- Triggers `specIndent` check 3a: WP body `r = n` is on a new line but at column 8, not 6.
@@ -108,7 +108,7 @@ theorem dummyI_postcond_body_ok_spec (n : Nat) :
 /--
 warning: Postcondition conjunct is at column 8, expected 6. Conjunction operands on new lines should be indented 6 spaces per the spec theorem style guide.
 
-Note: This linter can be disabled with `set_option linter.curve25519.specIndent false`
+Note: This linter can be disabled with `set_option linter.spqr.specIndent false`
 -/
 #guard_msgs in
 -- Triggers `specIndent` check 3b: `∧` RHS `r.2 = n` wraps to a new line at column 8.
@@ -133,7 +133,7 @@ theorem dummyP_postcond_ok_spec (n : Nat) :
 /--
 warning: ∧ operator should be appended to the end of the preceding line, not placed at the start of a new line, per the spec theorem style guide.
 
-Note: This linter can be disabled with `set_option linter.curve25519.specIndent false`
+Note: This linter can be disabled with `set_option linter.spqr.specIndent false`
 -/
 #guard_msgs in
 -- Triggers `specIndent` check 3b's operator-placement branch: the `∧` starts a new line
@@ -152,7 +152,7 @@ theorem dummyP_and_on_new_line_spec (n : Nat) :
 /--
 warning: Postcondition body is at column 8, expected 6. The postcondition body after `=>` should be indented 6 spaces per the spec theorem style guide.
 
-Note: This linter can be disabled with `set_option linter.curve25519.specIndent false`
+Note: This linter can be disabled with `set_option linter.spqr.specIndent false`
 -/
 #guard_msgs in
 -- The WP body is itself a conjunction that, as a whole, starts on a new line at column 8.
@@ -170,7 +170,7 @@ theorem dummyP_conj_body_misindent_spec (n : Nat) :
 /--
 warning: Proof body is at column 4, expected 2. Tactics after `by` should be indented 2 spaces per the project style guide.
 
-Note: This linter can be disabled with `set_option linter.curve25519.specIndent false`
+Note: This linter can be disabled with `set_option linter.spqr.specIndent false`
 -/
 #guard_msgs in
 -- Triggers `specIndent` check 4: first tactic is at column 4 instead of 2.
@@ -193,7 +193,7 @@ theorem dummyI_proof_ok_spec (n : Nat) :
 /--
 warning: Proof body is at column 4, expected 2. Tactics after `by` should be indented 2 spaces per the project style guide.
 
-Note: This linter can be disabled with `set_option linter.curve25519.specIndent false`
+Note: This linter can be disabled with `set_option linter.spqr.specIndent false`
 -/
 #guard_msgs in
 -- Plain theorem (no `@[step]`): only Check 4 applies, and it must fire on the bad indent.
@@ -226,7 +226,7 @@ theorem plain_proof_term_mode_ok (n : Nat) : n = n := rfl
 /--
 warning: Proof body is at column 4, expected 2. Tactics after `by` should be indented 2 spaces per the project style guide.
 
-Note: This linter can be disabled with `set_option linter.curve25519.specIndent false`
+Note: This linter can be disabled with `set_option linter.spqr.specIndent false`
 -/
 #guard_msgs in
 -- Plain theorem with BOTH a wrapped binder at column 2 (would-be Check 1 violation) and
@@ -238,7 +238,7 @@ theorem plain_both_violations_only_check4 (n : Nat)
 
 -- No warning: suppression via `set_option` must work on plain theorems too.
 #guard_msgs in
-set_option linter.curve25519.specIndent false in
+set_option linter.spqr.specIndent false in
 theorem plain_proof_suppressed_ok (n : Nat) : n = n := by
     rfl
 
@@ -246,7 +246,7 @@ theorem plain_proof_suppressed_ok (n : Nat) : n = n := by
 
 -- No warning expected: the whole indentation linter is suppressed.
 #guard_msgs in
-set_option linter.curve25519.specIndent false in
+set_option linter.spqr.specIndent false in
 @[step]
 theorem dummyI_suppressed_spec (n : Nat)
   (_h : n > 0) :
@@ -277,4 +277,4 @@ theorem dummyP_canonical2_spec
   simp
   simp [dummyP]
 
-end Curve25519Dalek.Lint.Test
+end Spqr.Lint.Test

--- a/Tests/LinterTest/SpecIndent.lean
+++ b/Tests/LinterTest/SpecIndent.lean
@@ -1,0 +1,280 @@
+/-
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Liao Zhang
+-/
+import Aeneas
+import Spqr.Lint.Basic
+
+/-!
+# Tests for `linter.curve25519.specIndent`
+
+Tests for the four indentation checks.  The first three checks fire only on `@[step]`
+theorems; the proof-body (Check 4) rule fires on every theorem.  Each `#guard_msgs` block
+targets exactly one violation so the expected-output annotation stays minimal.
+
+These tests live in the `Tests` Lake library (module `Tests.LinterTest.SpecIndent`) rather
+than in the `Curve25519Dalek` library, so the dummy theorems below (and their `@[step]`
+registrations) never leak into the production library or its public namespace.  They are
+additionally wrapped in the `Curve25519Dalek.Lint.Test` namespace as a second line of
+defence.
+-/
+
+open Aeneas Aeneas.Std Result Aeneas.Std.WP
+
+namespace Curve25519Dalek.Lint.Test
+
+-- Two minimal dummy functions for the test cases below.
+private def dummyI (n : Nat) : Result Nat := .ok n
+private def dummyP (n : Nat) : Result (Nat × Nat) := .ok ⟨n, n⟩
+
+/-! ## Check 1 — continuation line at wrong column -/
+
+/--
+warning: Continuation line is at column 2, expected 4. Arguments, preconditions, and the function application line on a new line should be indented 4 spaces per the spec theorem style guide.
+
+Note: This linter can be disabled with `set_option linter.curve25519.specIndent false`
+-/
+#guard_msgs in
+-- Triggers `specIndent` check 1: `(_h : n > 0)` wraps to a new line but uses only 2 spaces.
+@[step]
+theorem dummyI_binder_wrong_spec (n : Nat)
+  (_h : n > 0) :
+    dummyI n ⦃ (r : Nat) =>
+      r = n ⦄ := by
+  simp [dummyI]
+
+-- No warning: `(_h : n > 0)` starts on the theorem-keyword line, so the linter
+-- does not flag it — only binders whose node begins on a new line are checked.
+#guard_msgs in
+@[step]
+theorem dummyI_binder_ok_spec (n : Nat) (_h
+: n > 0) :
+    dummyI n ⦃ (r : Nat) =>
+      r = n ⦄ := by
+  simp [dummyI]
+
+/-! ## Check 1 (cont.) — function application line at wrong column -/
+
+/--
+warning: Continuation line is at column 2, expected 4. Arguments, preconditions, and the function application line on a new line should be indented 4 spaces per the spec theorem style guide.
+
+Note: This linter can be disabled with `set_option linter.curve25519.specIndent false`
+-/
+#guard_msgs in
+-- Triggers `specIndent` check 1: type term is on a new line but only 2 spaces deep.
+@[step]
+theorem dummyI_type_wrong_spec (n : Nat) :
+  dummyI n ⦃ (r : Nat) =>
+      r = n ⦄ := by
+  simp [dummyI]
+
+-- No warning: type term is correctly at column 4.
+#guard_msgs in
+@[step]
+theorem dummyI_type_ok_spec (n : Nat) :
+    dummyI n ⦃ (r : Nat) =>
+      r = n ⦄ := by
+  simp [dummyI]
+
+/-! ## Check 3 — postcondition at wrong column -/
+
+/-! ### Check 3a — first postcondition body at wrong column -/
+
+/--
+warning: Postcondition body is at column 8, expected 6. The postcondition body after `=>` should be indented 6 spaces per the spec theorem style guide.
+
+Note: This linter can be disabled with `set_option linter.curve25519.specIndent false`
+-/
+#guard_msgs in
+-- Triggers `specIndent` check 3a: WP body `r = n` is on a new line but at column 8, not 6.
+@[step]
+theorem dummyI_postcond_body_wrong_spec (n : Nat) :
+    dummyI n ⦃ (r : Nat) =>
+        r = n ⦄ := by
+  simp [dummyI]
+
+-- No warning: postcondition body is correctly at column 6.
+#guard_msgs in
+@[step]
+theorem dummyI_postcond_body_ok_spec (n : Nat) :
+    dummyI n ⦃ (r : Nat) =>
+      r = n ∧
+      r = n ∧ 1 = 1 ⦄ := by
+  simp [dummyI]
+
+/-! ### Check 3b — `∧` postcondition RHS at wrong column -/
+
+/--
+warning: Postcondition conjunct is at column 8, expected 6. Conjunction operands on new lines should be indented 6 spaces per the spec theorem style guide.
+
+Note: This linter can be disabled with `set_option linter.curve25519.specIndent false`
+-/
+#guard_msgs in
+-- Triggers `specIndent` check 3b: `∧` RHS `r.2 = n` wraps to a new line at column 8.
+-- The WP body `r.1 = n` is at column 6 (correct), so check 3a does not fire.
+@[step]
+theorem dummyP_postcond_wrong_spec (n : Nat) :
+    dummyP n ⦃ (r : Nat × Nat) =>
+      r.1 = n ∧
+        r.2 = n ⦄ := by
+  simp [dummyP]
+
+-- No warning: ∧ RHS is correctly at column 6.
+#guard_msgs in
+@[step]
+theorem dummyP_postcond_ok_spec (n : Nat) :
+    dummyP n ⦃ (r : Nat × Nat) =>
+      r.1 = n ∧ r.2 = n ⦄ := by
+  simp [dummyP]
+
+/-! ### Check 3b — `∧` operator placed at the start of a new line -/
+
+/--
+warning: ∧ operator should be appended to the end of the preceding line, not placed at the start of a new line, per the spec theorem style guide.
+
+Note: This linter can be disabled with `set_option linter.curve25519.specIndent false`
+-/
+#guard_msgs in
+-- Triggers `specIndent` check 3b's operator-placement branch: the `∧` starts a new line
+-- instead of being appended to the previous one.  The body is at column 6 (so check 3a
+-- does not fire) and the RHS shares the `∧` line (so the conjunct-indentation branch does
+-- not fire), isolating the operator-placement warning.
+@[step]
+theorem dummyP_and_on_new_line_spec (n : Nat) :
+    dummyP n ⦃ (r : Nat × Nat) =>
+      r.1 = n
+      ∧ r.2 = n ⦄ := by
+  simp [dummyP]
+
+/-! ### Check 3a/3b interaction — no double warning on a misindented conjunctive body -/
+
+/--
+warning: Postcondition body is at column 8, expected 6. The postcondition body after `=>` should be indented 6 spaces per the spec theorem style guide.
+
+Note: This linter can be disabled with `set_option linter.curve25519.specIndent false`
+-/
+#guard_msgs in
+-- The WP body is itself a conjunction that, as a whole, starts on a new line at column 8.
+-- Check 3a flags the body; Check 3b must be suppressed on this body so the single
+-- block-level indentation mistake yields exactly one message (not one per conjunct).
+@[step]
+theorem dummyP_conj_body_misindent_spec (n : Nat) :
+    dummyP n ⦃ (r : Nat × Nat) =>
+        r.1 = n ∧
+        r.2 = n ⦄ := by
+  simp [dummyP]
+
+/-! ## Check 4 — proof body after `by` at wrong column -/
+
+/--
+warning: Proof body is at column 4, expected 2. Tactics after `by` should be indented 2 spaces per the project style guide.
+
+Note: This linter can be disabled with `set_option linter.curve25519.specIndent false`
+-/
+#guard_msgs in
+-- Triggers `specIndent` check 4: first tactic is at column 4 instead of 2.
+@[step]
+theorem dummyI_proof_wrong_spec (n : Nat) :
+    dummyI n ⦃ (r : Nat) =>
+      r = n ⦄ := by
+    simp [dummyI]
+
+-- No warning: proof body is correctly at column 2.
+#guard_msgs in
+@[step]
+theorem dummyI_proof_ok_spec (n : Nat) :
+    dummyI n ⦃ (r : Nat) =>
+      r = n ⦄ := by
+  simp [dummyI]
+
+/-! ## Check 4 — non-`@[step]` theorems still get the proof-body indent rule -/
+
+/--
+warning: Proof body is at column 4, expected 2. Tactics after `by` should be indented 2 spaces per the project style guide.
+
+Note: This linter can be disabled with `set_option linter.curve25519.specIndent false`
+-/
+#guard_msgs in
+-- Plain theorem (no `@[step]`): only Check 4 applies, and it must fire on the bad indent.
+theorem plain_proof_wrong (n : Nat) : n = n := by
+    rfl
+
+-- No warning: plain theorem with proof body correctly at column 2.
+#guard_msgs in
+theorem plain_proof_ok (n : Nat) : n = n := by
+  rfl
+
+-- No warning: plain theorem violating the `@[step]`-only continuation-line rule
+-- (binder wraps to a new line at column 2) must NOT trigger any check, because
+-- Checks 1, 3a, 3b are gated on `@[step]`.
+#guard_msgs in
+theorem plain_binder_wrap_ok (n : Nat)
+  (_h : n > 0) : n = n := by
+  rfl
+
+-- No warning: `by` and the first tactic share a line — the proof body must start on a
+-- NEW line below `by` for Check 4 to fire, so `:= by rfl` is fine.
+#guard_msgs in
+theorem plain_proof_same_line_ok (n : Nat) : n = n := by rfl
+
+-- No warning: term-mode proof (`:= rfl`, not `:= by …`) has no by-tactic block at all,
+-- so `runProofBodyCheck` exits before reaching the indent comparison.
+#guard_msgs in
+theorem plain_proof_term_mode_ok (n : Nat) : n = n := rfl
+
+/--
+warning: Proof body is at column 4, expected 2. Tactics after `by` should be indented 2 spaces per the project style guide.
+
+Note: This linter can be disabled with `set_option linter.curve25519.specIndent false`
+-/
+#guard_msgs in
+-- Plain theorem with BOTH a wrapped binder at column 2 (would-be Check 1 violation) and
+-- a proof body at column 4.  Confirms that `runStepChecks` is gated off, so only the
+-- universal Check 4 warning is emitted — not Check 1.
+theorem plain_both_violations_only_check4 (n : Nat)
+  (_h : n > 0) : n = n := by
+    rfl
+
+-- No warning: suppression via `set_option` must work on plain theorems too.
+#guard_msgs in
+set_option linter.curve25519.specIndent false in
+theorem plain_proof_suppressed_ok (n : Nat) : n = n := by
+    rfl
+
+/-! ## Suppression -/
+
+-- No warning expected: the whole indentation linter is suppressed.
+#guard_msgs in
+set_option linter.curve25519.specIndent false in
+@[step]
+theorem dummyI_suppressed_spec (n : Nat)
+  (_h : n > 0) :
+  dummyI n ⦃ (r : Nat) => r = n ⦄ := by
+    simp [dummyI]
+
+/-! ## Fully-correct canonical layout — no warnings at all -/
+
+#guard_msgs in
+@[step]
+theorem dummyP_canonical_spec (n : Nat)
+    (_h : n > 0) :
+    dummyP n ⦃ (r : Nat × Nat) =>
+      r.1 = n ∧
+      (r.2 = n ∧ 1 = 1) ∧
+      2 = 2 ⦄ := by
+  simp [dummyP]
+
+#guard_msgs in
+@[step]
+theorem dummyP_canonical2_spec
+    (n : Nat)
+    (_h : n > 0) :
+    dummyP n ⦃ (r : Nat × Nat) =>
+      r.1 = n ∧
+      (r.2 = n ∧ 1 = 1) ∧
+      2 = 2 ⦄ := by
+  simp
+  simp [dummyP]
+
+end Curve25519Dalek.Lint.Test

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -19,3 +19,9 @@ name = "SrcTranslated"
 
 [[lean_lib]]
 name = "Spqr"
+
+# Test suites: the project-linter `#guard_msgs` tests (`Tests.LinterTest.*`) and the
+# property-based Plausible tests (`Tests.PlausibleTests.*`).  Deliberately NOT in
+# `defaultTargets`, so neither the dummy `@[step]` linter theorems nor the randomized
+[[lean_lib]]
+name = "Tests"


### PR DESCRIPTION
## Summary

Imports the spec-theorem indentation linter from dalek-lean, fixes a bug in it, and manually cleans up the warnings it surfaces.

- **Import linter**: brings over `Spqr/Lint/SpecIndent.lean` (the `linter.curve25519.specIndent` linter that checks spec theorems follow the style-guide indentation), plus `Spqr/Lint/Basic.lean`, wiring (`Spqr.lean`, `lakefile.toml`) and tests (`Tests/LinterTest/SpecIndent.lean`).
- **Fix a linter bug**: the linter no longer recurses into `∧` sub-terms when locating the postcondition body, so nested conjunctions are no longer mis-flagged.
- **Manually fix warnings**: corrected the indentation warnings discovered by the Linter.

Closes #204
Closes #180 