### PR TITLE
Specify: `spqr::authenticator::Authenticator::mac_ct` in `authenticator.rs`

### DIFF
--- a/Spqr.lean
+++ b/Spqr.lean
@@ -33,6 +33,7 @@ import Spqr.Specs.Aeneas.IntoIteratorSlice
 import Spqr.Specs.Aeneas.RangeIteratorNext
 import Spqr.Specs.Aeneas.SliceIteratorNext
 import Spqr.Specs.Authenticator.Authenticator.MACSIZE
+import Spqr.Specs.Authenticator.Authenticator.MacCt
 import Spqr.Specs.Authenticator.Serialize.Authenticator.IntoPb
 import Spqr.Specs.Encoding.Gf.GF16.Add
 import Spqr.Specs.Encoding.Gf.GF16.AddAssign

--- a/Spqr/Specs/Authenticator/Authenticator/MacCt.lean
+++ b/Spqr/Specs/Authenticator/Authenticator/MacCt.lean
@@ -1,0 +1,42 @@
+/-
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Markus Dablander
+-/
+import SrcTranslated.Funs
+import Spqr.Specs.Authenticator.Authenticator.MACSIZE
+
+/-!
+# Spec theorem for `spqr::authenticator::Authenticator::mac_ct`
+
+`mac_ct` produces an authentication tag that lets the receiver verify a
+ciphertext came from the legitimate sender and wasn't altered.
+
+The tag is computed by feeding three concatenated inputs into HMAC-SHA256 under
+a shared secret key:
+
+1. A fixed label identifying the tag's purpose (preventing confusion with tags
+   used elsewhere in the protocol).
+2. The current epoch counter.
+3. The ciphertext.
+
+The output is a 32-byte tag.
+
+**Source:** "spqr/src/authenticator.rs"
+-/
+
+open Aeneas Aeneas.Std Result Aeneas.Std.WP
+namespace spqr.authenticator.Authenticator
+
+/-- **Spec theorem for `spqr::authenticator::Authenticator::mac_ct`**
+• The call always succeeds (no panic).
+• The returned tag has length `MACSIZE` (= 32 bytes).
+-/
+@[step]
+theorem mac_ct_spec (self : Authenticator) (ep : U64)
+    (ct : Slice U8) :
+    mac_ct self ep ct ⦃ (result : alloc.vec.Vec U8) =>
+      result.length = MACSIZE.val ⦄ := by
+  sorry
+
+end spqr.authenticator.Authenticator


### PR DESCRIPTION
Closes #225

**Note:** While the content of this spec theorem appears correct and faithful to the realities of the underlying Rust in my estimation, the function in question (and thus its spec theorem proof) depends on an uninterpreted axiom stub in FunsExternal, namely on

```lean
/-- [libcrux_hmac::hmac]:
    Source: '/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libcrux-hmac-0.0.6/src/hmac.rs', lines 51:0-51:90
    Name pattern: [libcrux_hmac::hmac] -/
@[rust_fun "libcrux_hmac::hmac"]
axiom libcrux_hmac.hmac
  :
  libcrux_hmac.Algorithm → Slice Std.U8 → Slice Std.U8 → Option Std.Usize
    → Result (alloc.vec.Vec Std.U8)
```

Verifying the spec theorem in this PR will depend on somehow extending the above axiom (and thus the trust base of our repo) in a suitable manner. 

Due to the complexity of the involved entities, the usual strategy of simply extending the axiom to a faithful def that respects the Rust semantics and then adding a suitable, related step-tagged spec theorem for that def may not be applicable here. An alternative could be to simply add a suitable, related step-tagged spec axiom. 

As I am currently unsure how to optimally proceed here with maximum safety, and how to exactly draw the trust boundary around this axiom stub without subtly introducing a potenially false claim, I have opened a separate Issue (#226) for this so we can track and revisit this later.