### PR TITLE
Lean model for `Map`

### DIFF
--- a/SrcTranslated/FunsExternal.lean
+++ b/SrcTranslated/FunsExternal.lean
@@ -110,6 +110,59 @@ theorem core.hint.black_box_spec {T : Type} (x : T) :
     core.hint.black_box x ⦃ (r : T) => r = x ⦄ := by
   simp [core.hint.black_box]
 
+namespace core.iter
+namespace traits.iterator.Iterator
+
+-- Default implementations for Iterator fields
+def enumerate.default
+  {Self : Type} (self: Self) :
+  Result (core.iter.adapters.enumerate.Enumerate Self) :=
+  .ok ⟨ self, 0#usize ⟩
+
+def take.default
+  {Self : Type} (self: Self) (n: Usize):
+  Result (core.iter.adapters.take.Take Self) :=
+  .ok ⟨ self, n ⟩
+
+-- Since `next` is often the only custom method, we define a way to construct an entire
+-- `Iterator` from just the `next` function, and populate the rest with defaults.
+def fromNext
+  {Self: Type} {Self_Item: Type}
+  (nextFn: Self → Result ((Option Self_Item) × Self)) :
+  core.iter.traits.iterator.Iterator Self Self_Item :=
+  {
+    next := nextFn,
+    step_by := core.iter.traits.iterator.Iterator.step_by.default,
+    enumerate := enumerate.default,
+    take := take.default
+  }
+
+end traits.iterator.Iterator
+
+namespace adapters.map
+
+def mapIteratorTransformer
+  {I: Type} {A: Type} {B: Type} {F: Type}
+  (map: core.iter.adapters.map.Map I F)
+  (iterImpl: core.iter.traits.iterator.Iterator I A)
+  (fnImpl: core.ops.function.FnMut F A B) :
+  core.iter.traits.iterator.Iterator I B :=
+    -- we define the `next` behavior of the mapped-over iterator:
+    let mapNext (iter: I) : Result ((Option B) × I) := do
+      -- advance underlying iterator
+      let (opt, iter') ← iterImpl.next iter
+      match opt with
+      | none => ok (none, iter') -- If done, nothing to map over
+      | some val =>
+        -- If underlying iterator returns x, compute f(x). This may fail or diverge
+        let (postFnVal, _) ← fnImpl.call_mut map.f val
+        -- if execution reaches here, call_mut did not return div or fail
+        ok (some postFnVal, iter')
+    traits.iterator.Iterator.fromNext mapNext
+
+end adapters.map
+end core.iter
+
 /-- [core::iter::adapters::enumerate::{core::iter::traits::iterator::Iterator<(usize, Clause0_Item)> for core::iter::adapters::enumerate::Enumerate<I>}::next]:
     Source: '/rustc/library/core/src/iter/adapters/enumerate.rs', lines 79:4-79:64
     Name pattern: [core::iter::adapters::enumerate::{core::iter::traits::iterator::Iterator<core::iter::adapters::enumerate::Enumerate<@I>, (usize, @Clause0_Item)>}::next]
@@ -166,14 +219,15 @@ axiom
     Name pattern: [core::iter::adapters::enumerate::{core::iter::traits::iterator::Iterator<core::iter::adapters::enumerate::Enumerate<@I>, (usize, @Clause0_Item)>}::map] -/
 @[rust_fun
   "core::iter::adapters::enumerate::{core::iter::traits::iterator::Iterator<core::iter::adapters::enumerate::Enumerate<@I>, (usize, @Clause0_Item)>}::map"]
-axiom
+def
   core.iter.adapters.enumerate.Enumerate.Insts.CoreIterTraitsIteratorIteratorPairUsizeClause0_Item.map
   {I : Type} {B : Type} {F : Type} {Clause0_Item : Type}
-  (traitsiteratorIteratorInst : core.iter.traits.iterator.Iterator I
-  Clause0_Item) (opsfunctionFnMutFTuplePairUsizeClause0_ItemBInst :
-  core.ops.function.FnMut F (Std.Usize × Clause0_Item) B) :
-  core.iter.adapters.enumerate.Enumerate I → F → Result
-    (core.iter.adapters.map.Map (core.iter.adapters.enumerate.Enumerate I) F)
+  (traitsiteratorIteratorInst : core.iter.traits.iterator.Iterator I Clause0_Item)
+  (opsfunctionFnMutFTuplePairUsizeClause0_ItemBInst : core.ops.function.FnMut F (Std.Usize × Clause0_Item) B)
+  (self: core.iter.adapters.enumerate.Enumerate I)
+  (fn: F) : Result (core.iter.adapters.map.Map (core.iter.adapters.enumerate.Enumerate I) F) :=
+    -- The `.map` operation merely stores information that is computed on demand, so it cannot fail
+    ok ({iter := self, f := fn})
 
 /-- [core::iter::adapters::enumerate::{core::iter::traits::iterator::Iterator<(usize, Clause0_Item)> for core::iter::adapters::enumerate::Enumerate<I>}::step_by]:
     Source: '/rustc/library/core/src/iter/adapters/enumerate.rs', lines 62:0-64:16


### PR DESCRIPTION
<!--
Please ensure that your submitted PR follows our style guide and contribution rules.

All source code modifications, or proof cheats (`sorry`) must be highlighted and justified.

To see how your PR impacts performance, comment `!radar` and modify accordingly.
-->

This PR:
 - Partially addresses #114.
 - Adds semantics for iteration over a `.map` produced iterator (as an `Iterator -> Iterator` transformer)
 - Adds utility for generating an `Iterator` from a `next` function definition

Per our conversation, the current Aeneas treatment of iterators does not seem to define semantics for iterators produced by map. This code aims to supplement that.