### PR TITLE
Model KeyPairCompressedBytes as a concrete struct with proved specs

### DIFF
--- a/Spqr.lean
+++ b/Spqr.lean
@@ -80,6 +80,7 @@ import Spqr.Specs.Encoding.Polynomial.Poly.Zero
 import Spqr.Specs.Encoding.Polynomial.PolyConstN.ZEROS
 import Spqr.Specs.Encoding.Polynomial.Pt.Deserialize
 import Spqr.Specs.Encoding.Polynomial.Pt.Serialize
+import Spqr.Specs.IncrementalMlkem768.Generate
 import Spqr.Specs.Util.Compare
 import Spqr.Specs.Util.Inz
 import Spqr.Specs.Util.IsNonZero

--- a/Spqr/Specs/IncrementalMlkem768/Generate.lean
+++ b/Spqr/Specs/IncrementalMlkem768/Generate.lean
@@ -1,9 +1,10 @@
 /-
 Copyright 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Liao Zhang
 -/
-import Spqr.Code.Funs
-import Spqr.Code.FunsExternal
+import SrcTranslated.Funs
+import SrcTranslated.FunsExternal
 
 /-! # Spec theorem for `incremental_mlkem768::generate`
 
@@ -61,9 +62,11 @@ axiom sk_spec (k : KeyPairCompressedBytes) :
 
 /-- **Spec theorem for `incremental_mlkem768.generate`**:
 
-Assuming the RNG's `fill_bytes` does not panic, `generate` returns a `Keys` whose three buffers
-have the sizes mandated by the Rust contract: `hdr` is 64 bytes, `ek` is 1152 bytes, and `dk` is
-2400 bytes. -/
+- Assuming the RNG's `fill_bytes` does not panic
+- `generate` returns a `Keys` whose three buffers have the sizes mandated by the Rust contract
+  * `hdr` is 64 bytes
+  * `ek` is 1152 bytes
+  * and `dk` is 2400 bytes. -/
 theorem generate_spec {R : Type} (rngInst : rand.rng.Rng R)
     (cryptoInst : rand_core.CryptoRng R) (rng : R)
     (h_fill : ∀ (r : R) (s : Slice Std.U8),

--- a/Spqr/Specs/IncrementalMlkem768/Generate.lean
+++ b/Spqr/Specs/IncrementalMlkem768/Generate.lean
@@ -44,20 +44,45 @@ open libcrux_ml_kem.mlkem768.incremental
 open Spqr.Mlkem
 /-- **Spec theorem for `incremental_mlkem768.generate`**:
 
-- Assuming the RNG's `fill_bytes` does not panic
-- `generate` returns a `Keys` whose three buffers have the sizes mandated by the Rust contract
-  * `hdr` is 64 bytes
-  * `ek` is 1152 bytes
-  * and `dk` is 2400 bytes. -/
+Assuming the RNG's `fill_bytes` does not panic, `generate` returns a `Keys` that is the
+*serialization of a single compressed ML-KEM key pair* — not merely three independent buffers
+of the right size.  Concretely, there is one key pair `kp` (the one libcrux derives from the
+freshly sampled 64-byte randomness) such that the three returned buffers are exactly its
+`pk1`/`pk2`/`sk` projections, byte-for-byte:
+
+  * `hdr` is the header `kp.pk1Bytes`,
+  * `ek`  is the encapsulation key `kp.pk2Bytes`,
+  * `dk`  is the decapsulation key `kp.skBytes`.
+
+This `(hdr, ek, dk)` ↦ `(pk1, pk2, sk)` correspondence is the relationship that ties the three
+outputs together; the contractual sizes (`64`, `1152`, `2400`) then follow because `kp`'s fields
+are fixed-size arrays.  The *cryptographic* content of `kp` is opaque in this model (libcrux's
+`from_seed` is an external whose key-derivation is not modelled), so this is the strongest
+relationship the model supports — it pins the structure and provenance of the output, not the
+algebraic key-generation itself. -/
 theorem generate_spec {R : Type} (rngInst : rand.rng.Rng R)
     (cryptoInst : rand_core.CryptoRng R) (rng : R)
     (h_fill : ∀ (r : R) (s : Slice Std.U8),
       rngInst.rand_coreRngCoreInst.fill_bytes r s ⦃ fun _ => True ⦄) :
     generate rngInst cryptoInst rng ⦃ (result : Keys × R) =>
-      result.1.hdr.length = 64 ∧
-      result.1.ek.length = 1152 ∧
-      result.1.dk.length = 2400 ⦄ := by
+      ∃ kp : libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes,
+        -- the three output buffers are the `pk1`/`pk2`/`sk` projections of *one and the
+        -- same* compressed key pair `kp`, byte-for-byte (not merely buffers of the right size)
+        result.1.hdr.val = kp.pk1Bytes.val ∧
+        result.1.ek.val  = kp.pk2Bytes.val ∧
+        result.1.dk.val  = kp.skBytes.val ∧
+        -- the sizes mandated by the Rust contract follow, since `kp`'s fields are fixed-size
+        result.1.hdr.length = 64 ∧
+        result.1.ek.length = 1152 ∧
+        result.1.dk.length = 2400 ⦄ := by
   unfold generate
   step*
+  -- All three buffers are the `pk1`/`pk2`/`sk` projections of the *same* key pair `k`
+  -- (the one derived from the freshly sampled randomness); `to_slice`/`to_vec` only copy
+  -- the underlying bytes, so both the contents and the sizes are preserved.
+  refine ⟨k, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;>
+    simp only [← v_post, ← v1_post, ← v2_post, s2_post, s3_post, s4_post,
+      a_post, a1_post, a2_post, Array.val_to_slice, Array.length_to_slice] <;>
+    rfl
 
 end spqr.incremental_mlkem768

--- a/Spqr/Specs/IncrementalMlkem768/Generate.lean
+++ b/Spqr/Specs/IncrementalMlkem768/Generate.lean
@@ -25,10 +25,13 @@ in `SrcTranslated/TypesExternal.lean` (`headerBytes = 64`,
 
 The libcrux routines `KeyPairCompressedBytes::{from_seed, pk1, pk2, sk}` are externals whose
 return *types* already pin the array sizes (`[u8; 64]`, `[u8; 1152]`, `[u8; 2400]`).  They are
-modelled in `SrcTranslated/FunsExternal.lean` as honest `def`s over a concrete
-`KeyPairCompressedBytes` struct — whose field lengths are exactly those derived sizes — each
-with a proved `@[step]` spec stating only that the call does not panic (the cryptographic
-content is not modelled).
+modelled in `SrcTranslated/FunsExternal.lean` over a concrete `KeyPairCompressedBytes` struct
+that faithfully mirrors the Rust one: a *single* serialized buffer `value` of length
+`decapsulationKeyBytes = 2400`, of which `sk` returns the whole thing and `pk1`/`pk2` are
+byte-for-byte *slices* (`value[2·enc .. 2·enc+64]` and `value[enc .. 2·enc]`, with
+`enc = encapsulationKeyBytes = 1152`).  `from_seed` carries an `@[step]` spec stating only that
+the resulting buffer has the mandated size (the cryptographic content is not modelled); the
+slice accessors carry proved `@[step]` specs recording both their size and their slice provenance.
 `RngCore::fill_bytes` is a trait method on an arbitrary `R`, so its
 non-panicking behaviour is taken as a hypothesis on the instance.  The output buffer lengths are
 then independent of the randomness: `from_slice` reconstructs a `[u8; 64]` regardless, so the
@@ -47,19 +50,21 @@ open Spqr.Mlkem
 Assuming the RNG's `fill_bytes` does not panic, `generate` returns a `Keys` that is the
 *serialization of a single compressed ML-KEM key pair* — not merely three independent buffers
 of the right size.  Concretely, there is one key pair `kp` (the one libcrux derives from the
-freshly sampled 64-byte randomness) such that the three returned buffers are exactly its
-`pk1`/`pk2`/`sk` projections, byte-for-byte:
+freshly sampled 64-byte randomness) whose single serialized buffer `kp.value` is the source of
+all three outputs, byte-for-byte:
 
-  * `hdr` is the header `kp.pk1Bytes`,
-  * `ek`  is the encapsulation key `kp.pk2Bytes`,
-  * `dk`  is the decapsulation key `kp.skBytes`.
+  * `dk`  is the *whole* decapsulation-key buffer `kp.value`;
+  * `ek`  is the encapsulation-key (`t̂`) sub-range `kp.value[enc .. 2·enc]`;
+  * `hdr` is the header sub-range `kp.value[2·enc .. 2·enc + 64]`,
 
-This `(hdr, ek, dk)` ↦ `(pk1, pk2, sk)` correspondence is the relationship that ties the three
-outputs together; the contractual sizes (`64`, `1152`, `2400`) then follow because `kp`'s fields
-are fixed-size arrays.  The *cryptographic* content of `kp` is opaque in this model (libcrux's
-`from_seed` is an external whose key-derivation is not modelled), so this is the strongest
-relationship the model supports — it pins the structure and provenance of the output, not the
-algebraic key-generation itself. -/
+with `enc = encapsulationKeyBytes = 1152`.  Because the model stores one shared buffer rather
+than three independent fields, the fact that `hdr`/`ek` are *sub-ranges of* `dk` is exact (a
+`List.slice` equality), mirroring the Rust accessors that slice the same `value`.  The
+contractual sizes (`64`, `1152`, `2400`) then follow because `kp.value` is a fixed-size array.
+The *cryptographic* content of `kp.value` is opaque in this model (libcrux's `from_seed` is an
+external whose key-derivation is not modelled), so this is the strongest relationship the model
+supports — it pins the structure and provenance of the output, not the algebraic key-generation
+itself. -/
 theorem generate_spec {R : Type} (rngInst : rand.rng.Rng R)
     (cryptoInst : rand_core.CryptoRng R) (rng : R)
     (h_fill : ∀ (r : R) (s : Slice Std.U8),
@@ -67,22 +72,29 @@ theorem generate_spec {R : Type} (rngInst : rand.rng.Rng R)
     generate rngInst cryptoInst rng ⦃ (result : Keys × R) =>
       ∃ kp : libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes,
         -- the three output buffers are the `pk1`/`pk2`/`sk` projections of *one and the
-        -- same* compressed key pair `kp`, byte-for-byte (not merely buffers of the right size)
-        result.1.hdr.val = kp.pk1Bytes.val ∧
-        result.1.ek.val  = kp.pk2Bytes.val ∧
-        result.1.dk.val  = kp.skBytes.val ∧
-        -- the sizes mandated by the Rust contract follow, since `kp`'s fields are fixed-size
+        -- same* compressed key pair `kp`, byte-for-byte: `dk` is the whole serialized
+        -- buffer `kp.value`, and `hdr`/`ek` are the header / `t̂` *sub-ranges* of that same
+        -- buffer (not merely buffers of the right size)
+        result.1.hdr.val = kp.value.val.slice
+          (2 * mlkem768Params.encapsulationKeyBytes)
+          (2 * mlkem768Params.encapsulationKeyBytes + headerBytes) ∧
+        result.1.ek.val  = kp.value.val.slice
+          mlkem768Params.encapsulationKeyBytes
+          (2 * mlkem768Params.encapsulationKeyBytes) ∧
+        result.1.dk.val  = kp.value.val ∧
+        -- the sizes mandated by the Rust contract follow, since `kp.value` is a fixed-size buffer
         result.1.hdr.length = 64 ∧
         result.1.ek.length = 1152 ∧
         result.1.dk.length = 2400 ⦄ := by
   unfold generate
   step*
-  -- All three buffers are the `pk1`/`pk2`/`sk` projections of the *same* key pair `k`
-  -- (the one derived from the freshly sampled randomness); `to_slice`/`to_vec` only copy
-  -- the underlying bytes, so both the contents and the sizes are preserved.
+  -- All three buffers come from the *same* key pair `k` (the one derived from the freshly
+  -- sampled randomness): `dk` is its whole `value` buffer and `hdr`/`ek` are slices of that
+  -- same buffer; `to_slice`/`to_vec` only copy the underlying bytes, so both the contents and
+  -- the sizes are preserved.
   refine ⟨k, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;>
     simp only [← v_post, ← v1_post, ← v2_post, s2_post, s3_post, s4_post,
-      a_post, a1_post, a2_post, Array.val_to_slice, Array.length_to_slice] <;>
+      a_post2, a1_post2, a2_post2, Array.val_to_slice, Array.length_to_slice] <;>
     rfl
 
 end spqr.incremental_mlkem768

--- a/Spqr/Specs/IncrementalMlkem768/Generate.lean
+++ b/Spqr/Specs/IncrementalMlkem768/Generate.lean
@@ -50,38 +50,30 @@ open Spqr.Mlkem
 
 /-- **Spec theorem for `incremental_mlkem768.generate`**:
 
-Assuming the RNG's `fill_bytes` does not panic, `generate` returns a `Keys` that is the
-*serialization of a single compressed ML-KEM key pair* — not merely three independent buffers
-of the right size.  Concretely, there is one key pair `kp` (the one libcrux derives from the
-freshly sampled 64-byte randomness) whose single serialized buffer `kp.value` is the source of
-all three outputs, byte-for-byte:
+Assuming `fill_bytes` is panic-free, `generate` returns a `Keys` that is the serialization of a
+*single* compressed ML-KEM key pair `kp` — not three independent buffers of the right size.  All
+three outputs come, byte-for-byte, from `kp`'s one serialized buffer `kp.value`
+(`enc = encapsulationKeyBytes = 1152`):
 
-  * `dk`  is the *whole* decapsulation-key buffer `kp.value`;
-  * `ek`  is the encapsulation-key (`t̂`) sub-range `kp.value[enc .. 2·enc]`;
-  * `hdr` is the header sub-range `kp.value[2·enc .. 2·enc + 64]`,
+  * `dk`  = the *whole* buffer `kp.value`                 (length `2400`);
+  * `ek`  = the `t̂` sub-range `kp.value[enc .. 2·enc]`    (length `1152`);
+  * `hdr` = the header sub-range `kp.value[2·enc .. 2·enc + 64]` (length `64`).
 
-with `enc = encapsulationKeyBytes = 1152`.  Because the model stores one shared buffer rather
-than three independent fields, the fact that `hdr`/`ek` are *sub-ranges of* `dk` is exact (a
-`List.slice` equality), mirroring the Rust accessors that slice the same `value`.  The
-contractual sizes (`64`, `1152`, `2400`) then follow because `kp.value` is a fixed-size array.
-The *cryptographic* content of `kp.value` is left for furture work.
+Because the model stores one shared buffer, the slice provenance is *exact* — `List.slice`
+equalities, not just length facts — mirroring the Rust accessors that slice the same `value`; the
+contractual sizes follow since `kp.value` is fixed-size.
 
-TODO:
-- Functional correctness (round-trip). For (ek, dk) from generate, any shared secret encapsulated to
-  ek is recovered by decapsulating with dk:
-  decaps(dk, encaps(ek)) = ss, up to ML-KEM's negligible (~2⁻¹³⁸) failure probability. This is the minimal
-  crypto-functional property, and it's the one the current model cannot state because from_seed/encaps/decaps are
-  opaque size-only externals.
+TODO: the *cryptographic* content of `kp.value` is left to future work; the size-only externals
+(`from_seed`/`encaps`/`decaps`) cannot yet state:
 
-  2. Distributional faithfulness. (ek, dk) is identically distributed to ML-KEM-768 KeyGen on a uniform seed. This
-  is the bridge to all security: IND-CCA2 only transfers to these keys if their distribution is correct.
-
-  3. Security (inherited, game-based). Given (2): the KEM built on (ek, dk) is IND-CCA2; ek/hdr are pseudorandom
-  (safe to transmit — MLWE hides t̂); and the secret portion of dk (i.e. dk \ (ek‖hdr) — dk_pke, z) is one-way /
-  computationally hidden given the transmitted (hdr, ek). The subtlety from the layout above: secrecy is not that
-  ek/hdr bytes are disjoint from dk — they aren't — it's that the complement slices stay hidden.
-
--/
+1. **Round-trip correctness.** `decaps(dk, encaps(ek)) = ss`, up to ML-KEM's negligible
+   (~2⁻¹³⁸) failure probability.
+2. **Distributional faithfulness.** `(ek, dk)` is identically distributed to ML-KEM-768 KeyGen on
+   a uniform seed — the bridge that transfers security to these keys.
+3. **Security (game-based, given 2).** The KEM is IND-CCA2; `ek`/`hdr` are pseudorandom (MLWE
+   hides `t̂`, safe to transmit); the secret complement `dk \ (ek‖hdr)` stays computationally
+   hidden.  Note secrecy is *not* byte-disjointness (the bytes overlap) but that the complement
+   slices stay hidden. -/
 theorem generate_spec {R : Type} (rngInst : rand.rng.Rng R)
     (cryptoInst : rand_core.CryptoRng R) (rng : R)
     (h_fill : ∀ (r : R) (s : Slice Std.U8),

--- a/Spqr/Specs/IncrementalMlkem768/Generate.lean
+++ b/Spqr/Specs/IncrementalMlkem768/Generate.lean
@@ -66,9 +66,9 @@ theorem generate_spec {R : Type} (rngInst : rand.rng.Rng R)
         (2 * mlkem768Params.encapsulationKeyBytes) ∧
         result.1.hdr.val = result.1.dk.val.slice (2 * mlkem768Params.encapsulationKeyBytes)
         (2 * mlkem768Params.encapsulationKeyBytes + headerBytes) ∧
-        result.1.hdr.length = 64 ∧
-        result.1.ek.length = 1152 ∧
-        result.1.dk.length = 2400 ⦄ := by
+        result.1.hdr.length = headerBytes ∧
+        result.1.ek.length = mlkem768Params.encapsulationKeyBytes ∧
+        result.1.dk.length = mlkem768Params.decapsulationKeyBytes ⦄ := by
   unfold generate
   step*
   refine ⟨?_, ?_, ?_⟩ <;>

--- a/Spqr/Specs/IncrementalMlkem768/Generate.lean
+++ b/Spqr/Specs/IncrementalMlkem768/Generate.lean
@@ -20,10 +20,12 @@ sizes of those buffers:
 
 with `HEADER_SIZE = 64` and `ENCAPSULATION_KEY_SIZE = 1152`.
 
-The libcrux routines `KeyPairCompressedBytes::{from_seed, pk1, pk2, sk}` are opaque externals
-whose return *types* already pin the array sizes (`[u8; 64]`, `[u8; 1152]`, `[u8; 2400]`); we
-only postulate that they do not panic (return `ok`), mirroring the admitted libcrux interface
-used by the hax extraction.  `RngCore::fill_bytes` is a trait method on an arbitrary `R`, so its
+The libcrux routines `KeyPairCompressedBytes::{from_seed, pk1, pk2, sk}` are externals whose
+return *types* already pin the array sizes (`[u8; 64]`, `[u8; 1152]`, `[u8; 2400]`).  They are
+modelled in `SrcTranslated/FunsExternal.lean` as honest `def`s over a concrete
+`KeyPairCompressedBytes` struct, each with a proved `@[step]` spec stating only that the call
+does not panic (the cryptographic content is not modelled).
+`RngCore::fill_bytes` is a trait method on an arbitrary `R`, so its
 non-panicking behaviour is taken as a hypothesis on the instance.  The output buffer lengths are
 then independent of the randomness: `from_slice` reconstructs a `[u8; 64]` regardless, so the
 sizes follow from the `pk1`/`pk2`/`sk` return types through `to_slice`/`to_vec`.
@@ -35,30 +37,6 @@ open Aeneas Aeneas.Std Result
 namespace spqr.incremental_mlkem768
 
 open libcrux_ml_kem.mlkem768.incremental
-
-/-- Trusted interface spec: `KeyPairCompressedBytes::from_seed` does not panic.  The result type
-`KeyPairCompressedBytes` carries no size obligation, so the postcondition is trivial. -/
-@[step]
-axiom from_seed_spec (x : Array Std.U8 64#usize) :
-    KeyPairCompressedBytes.from_seed x ⦃ fun _ => True ⦄
-
-/-- Trusted interface spec: `KeyPairCompressedBytes::pk1` does not panic.  Its return type
-`[u8; 64]` pins the header size. -/
-@[step]
-axiom pk1_spec (k : KeyPairCompressedBytes) :
-    KeyPairCompressedBytes.pk1 k ⦃ fun (_ : Array Std.U8 64#usize) => True ⦄
-
-/-- Trusted interface spec: `KeyPairCompressedBytes::pk2` does not panic.  Its return type
-`[u8; 1152]` pins the encapsulation-key size. -/
-@[step]
-axiom pk2_spec (k : KeyPairCompressedBytes) :
-    KeyPairCompressedBytes.pk2 k ⦃ fun (_ : Array Std.U8 1152#usize) => True ⦄
-
-/-- Trusted interface spec: `KeyPairCompressedBytes::sk` does not panic.  Its return type
-`[u8; 2400]` pins the decapsulation-key size. -/
-@[step]
-axiom sk_spec (k : KeyPairCompressedBytes) :
-    KeyPairCompressedBytes.sk k ⦃ fun (_ : Array Std.U8 2400#usize) => True ⦄
 
 /-- **Spec theorem for `incremental_mlkem768.generate`**:
 

--- a/Spqr/Specs/IncrementalMlkem768/Generate.lean
+++ b/Spqr/Specs/IncrementalMlkem768/Generate.lean
@@ -45,6 +45,8 @@ namespace spqr.incremental_mlkem768
 
 open libcrux_ml_kem.mlkem768.incremental
 open Spqr.Mlkem
+open mlkem768Params
+
 /-- **Spec theorem for `incremental_mlkem768.generate`**:
 
 Assuming the RNG's `fill_bytes` does not panic, `generate` returns a `Keys` that is the
@@ -70,31 +72,23 @@ theorem generate_spec {R : Type} (rngInst : rand.rng.Rng R)
     (h_fill : ∀ (r : R) (s : Slice Std.U8),
       rngInst.rand_coreRngCoreInst.fill_bytes r s ⦃ fun _ => True ⦄) :
     generate rngInst cryptoInst rng ⦃ (result : Keys × R) =>
-      ∃ kp : libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes,
-        -- the three output buffers are the `pk1`/`pk2`/`sk` projections of *one and the
-        -- same* compressed key pair `kp`, byte-for-byte: `dk` is the whole serialized
-        -- buffer `kp.value`, and `hdr`/`ek` are the header / `t̂` *sub-ranges* of that same
-        -- buffer (not merely buffers of the right size)
-        result.1.hdr.val = kp.value.val.slice
-          (2 * mlkem768Params.encapsulationKeyBytes)
-          (2 * mlkem768Params.encapsulationKeyBytes + headerBytes) ∧
-        result.1.ek.val  = kp.value.val.slice
-          mlkem768Params.encapsulationKeyBytes
-          (2 * mlkem768Params.encapsulationKeyBytes) ∧
-        result.1.dk.val  = kp.value.val ∧
-        -- the sizes mandated by the Rust contract follow, since `kp.value` is a fixed-size buffer
+        result.1.ek.val  = result.1.dk.val.slice mlkem768Params.encapsulationKeyBytes
+        (2 * mlkem768Params.encapsulationKeyBytes) ∧
+        result.1.hdr.val = result.1.dk.val.slice (2 * mlkem768Params.encapsulationKeyBytes)
+        (2 * mlkem768Params.encapsulationKeyBytes + headerBytes) ∧
         result.1.hdr.length = 64 ∧
         result.1.ek.length = 1152 ∧
         result.1.dk.length = 2400 ⦄ := by
-  unfold generate
-  step*
-  -- All three buffers come from the *same* key pair `k` (the one derived from the freshly
-  -- sampled randomness): `dk` is its whole `value` buffer and `hdr`/`ek` are slices of that
-  -- same buffer; `to_slice`/`to_vec` only copy the underlying bytes, so both the contents and
-  -- the sizes are preserved.
-  refine ⟨k, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;>
-    simp only [← v_post, ← v1_post, ← v2_post, s2_post, s3_post, s4_post,
-      a_post2, a1_post2, a2_post2, Array.val_to_slice, Array.length_to_slice] <;>
-    rfl
+  sorry
+  -- unfold generate
+  -- step*
+  -- -- All three buffers come from the *same* key pair `k` (the one derived from the freshly
+  -- -- sampled randomness): `dk` is its whole `value` buffer and `hdr`/`ek` are slices of that
+  -- -- same buffer; `to_slice`/`to_vec` only copy the underlying bytes, so both the contents and
+  -- -- the sizes are preserved.
+  -- refine ⟨k, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;>
+  --   simp only [← v_post, ← v1_post, ← v2_post, s2_post, s3_post, s4_post,
+  --     a_post2, a1_post2, a2_post2, Array.val_to_slice, Array.length_to_slice] <;>
+  --   rfl
 
 end spqr.incremental_mlkem768

--- a/Spqr/Specs/IncrementalMlkem768/Generate.lean
+++ b/Spqr/Specs/IncrementalMlkem768/Generate.lean
@@ -8,36 +8,38 @@ import SrcTranslated.FunsExternal
 
 /-! # Spec theorem for `incremental_mlkem768::generate`
 
-`generate` draws fresh randomness, derives a compressed ML-KEM key pair via libcrux, and
-returns the three serialized buffers `(hdr, ek, dk)`.  The Rust contract is purely about the
-sizes of those buffers:
+`generate` is ML-KEM-768 key generation packaged for the SPQR ratchet: it samples a fresh
+64-byte seed from a cryptographically secure RNG, derives a compressed ML-KEM-768 key pair via
+libcrux, and returns the three serialized buffers `(hdr, ek, dk)` that the protocol transmits
+and stores.
 
-```
-#[hax_lib::ensures(|result|
-  result.hdr.len() == HEADER_SIZE && result.ek.len() == ENCAPSULATION_KEY_SIZE
-  && result.dk.len() == 2400)]
-```
+The extracted body in `SrcTranslated/Funs.lean` proceeds in four steps:
+* allocate a 64-byte zero buffer and overwrite it via `RngCore::fill_bytes` — the fresh seed;
+* `KeyPairCompressedBytes::from_seed seed` — libcrux's ML-KEM-768 keygen, returning one
+  compressed key pair `k`;
+* read the three projections `k.pk1 ()`, `k.pk2 ()`, `k.sk ()` — the 64-byte header, the
+  1152-byte encapsulation key (the serialized `t̂` vector), and the 2400-byte decapsulation key;
+* copy each into an owned `Vec` (`to_slice` then `to_vec`) and assemble `Keys { hdr, ek, dk }`.
 
-with `HEADER_SIZE = 64` and `ENCAPSULATION_KEY_SIZE = 1152`.  These three sizes are not bare
-literals in the model: they are the buffer lengths *derived* from the ML-KEM-768 parameter set
-in `SrcTranslated/TypesExternal.lean` (`headerBytes = 64`,
-`mlkem768Params.encapsulationKeyBytes = 1152`, `mlkem768Params.decapsulationKeyBytes = 2400`).
+Cryptographically the three buffers are *not* independent: ML-KEM's decapsulation key embeds the
+public key.  In the serialized layout `dk` is the whole key pair, `ek` is the sub-range
+`dk[enc .. 2·enc]`, and `hdr` is the sub-range `dk[2·enc .. 2·enc + 64]`, where
+`enc = encapsulationKeyBytes = 1152`.  These containments — not just the lengths — are exactly
+what the spec theorem proves.
 
-The libcrux routines `KeyPairCompressedBytes::{from_seed, pk1, pk2, sk}` are externals whose
-return *types* already pin the array sizes (`[u8; 64]`, `[u8; 1152]`, `[u8; 2400]`).  They are
-modelled in `SrcTranslated/FunsExternal.lean` over a concrete `KeyPairCompressedBytes` struct
-that faithfully mirrors the Rust one: a *single* serialized buffer `value` of length
-`decapsulationKeyBytes = 2400`, of which `sk` returns the whole thing and `pk1`/`pk2` are
-byte-for-byte *slices* (`value[2·enc .. 2·enc+64]` and `value[enc .. 2·enc]`, with
-`enc = encapsulationKeyBytes = 1152`).  `from_seed` carries an `@[step]` spec stating only that
-the resulting buffer has the mandated size (the cryptographic content is not modelled); the
-slice accessors carry proved `@[step]` specs recording both their size and their slice provenance.
-`RngCore::fill_bytes` is a trait method on an arbitrary `R`, so its
-non-panicking behaviour is taken as a hypothesis on the instance.  The output buffer lengths are
-then independent of the randomness: `from_slice` reconstructs a `[u8; 64]` regardless, so the
-sizes follow from the `pk1`/`pk2`/`sk` return types through `to_slice`/`to_vec`.
+`KeyPairCompressedBytes::{from_seed, pk1, pk2, sk}` are externals modelled in
+`SrcTranslated/FunsExternal.lean` over a concrete `KeyPairCompressedBytes` that faithfully
+mirrors the Rust struct: a *single* serialized buffer `value` of length
+`mlkem768Params.decapsulationKeyBytes = 2400`.  Over it `sk` returns the whole buffer, `pk2` the
+slice `value[enc .. 2·enc]`, and `pk1` the slice `value[2·enc .. 2·enc + 64]`, where
+`enc = mlkem768Params.encapsulationKeyBytes = 1152`.  The three contractual sizes are therefore
+not bare literals but the buffer lengths *derived* from the ML-KEM-768 parameter set in
+`SrcTranslated/TypesExternal.lean` (`headerBytes = 64`, `encapsulationKeyBytes = 1152`,
+`decapsulationKeyBytes = 2400`).  `pk1`/`pk2`/`sk` carry proved `@[step]` specs recording both
+their length and their slice provenance; `from_seed` carries an `@[step]` spec fixing only the
+length of its buffer (its key derivation is not modelled).
 
-**Source**: spqr/src/incremental_mlkem768.rs (lines 34:0-43:1) -/
+**Source**: `src/incremental_mlkem768.rs`, lines 34:0-43:1 -/
 
 open Aeneas Aeneas.Std Result
 
@@ -62,10 +64,24 @@ with `enc = encapsulationKeyBytes = 1152`.  Because the model stores one shared 
 than three independent fields, the fact that `hdr`/`ek` are *sub-ranges of* `dk` is exact (a
 `List.slice` equality), mirroring the Rust accessors that slice the same `value`.  The
 contractual sizes (`64`, `1152`, `2400`) then follow because `kp.value` is a fixed-size array.
-The *cryptographic* content of `kp.value` is opaque in this model (libcrux's `from_seed` is an
-external whose key-derivation is not modelled), so this is the strongest relationship the model
-supports — it pins the structure and provenance of the output, not the algebraic key-generation
-itself. -/
+The *cryptographic* content of `kp.value` is left for furture work.
+
+TODO:
+- Functional correctness (round-trip). For (ek, dk) from generate, any shared secret encapsulated to
+  ek is recovered by decapsulating with dk:
+  decaps(dk, encaps(ek)) = ss, up to ML-KEM's negligible (~2⁻¹³⁸) failure probability. This is the minimal
+  crypto-functional property, and it's the one the current model cannot state because from_seed/encaps/decaps are
+  opaque size-only externals.
+
+  2. Distributional faithfulness. (ek, dk) is identically distributed to ML-KEM-768 KeyGen on a uniform seed. This
+  is the bridge to all security: IND-CCA2 only transfers to these keys if their distribution is correct.
+
+  3. Security (inherited, game-based). Given (2): the KEM built on (ek, dk) is IND-CCA2; ek/hdr are pseudorandom
+  (safe to transmit — MLWE hides t̂); and the secret portion of dk (i.e. dk \ (ek‖hdr) — dk_pke, z) is one-way /
+  computationally hidden given the transmitted (hdr, ek). The subtlety from the layout above: secrecy is not that
+  ek/hdr bytes are disjoint from dk — they aren't — it's that the complement slices stay hidden.
+
+-/
 theorem generate_spec {R : Type} (rngInst : rand.rng.Rng R)
     (cryptoInst : rand_core.CryptoRng R) (rng : R)
     (h_fill : ∀ (r : R) (s : Slice Std.U8),
@@ -78,16 +94,10 @@ theorem generate_spec {R : Type} (rngInst : rand.rng.Rng R)
         result.1.hdr.length = 64 ∧
         result.1.ek.length = 1152 ∧
         result.1.dk.length = 2400 ⦄ := by
-  sorry
-  -- unfold generate
-  -- step*
-  -- -- All three buffers come from the *same* key pair `k` (the one derived from the freshly
-  -- -- sampled randomness): `dk` is its whole `value` buffer and `hdr`/`ek` are slices of that
-  -- -- same buffer; `to_slice`/`to_vec` only copy the underlying bytes, so both the contents and
-  -- -- the sizes are preserved.
-  -- refine ⟨k, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;>
-  --   simp only [← v_post, ← v1_post, ← v2_post, s2_post, s3_post, s4_post,
-  --     a_post2, a1_post2, a2_post2, Array.val_to_slice, Array.length_to_slice] <;>
-  --   rfl
+  unfold generate
+  step*
+  refine ⟨?_, ?_, ?_⟩ <;>
+  simp only [← v_post, ← v1_post, ← v2_post, s2_post, s3_post, s4_post,
+    a_post2, a1_post2, a2_post2, Array.val_to_slice, Array.length_to_slice] ; grind
 
 end spqr.incremental_mlkem768

--- a/Spqr/Specs/IncrementalMlkem768/Generate.lean
+++ b/Spqr/Specs/IncrementalMlkem768/Generate.lean
@@ -45,7 +45,6 @@ namespace spqr.incremental_mlkem768
 
 open libcrux_ml_kem.mlkem768.incremental
 open Spqr.Mlkem
-open mlkem768Params
 
 /-- **Spec theorem for `incremental_mlkem768.generate`**:
 

--- a/Spqr/Specs/IncrementalMlkem768/Generate.lean
+++ b/Spqr/Specs/IncrementalMlkem768/Generate.lean
@@ -27,18 +27,6 @@ public key.  In the serialized layout `dk` is the whole key pair, `ek` is the su
 `enc = encapsulationKeyBytes = 1152`.  These containments — not just the lengths — are exactly
 what the spec theorem proves.
 
-`KeyPairCompressedBytes::{from_seed, pk1, pk2, sk}` are externals modelled in
-`SrcTranslated/FunsExternal.lean` over a concrete `KeyPairCompressedBytes` that faithfully
-mirrors the Rust struct: a *single* serialized buffer `value` of length
-`mlkem768Params.decapsulationKeyBytes = 2400`.  Over it `sk` returns the whole buffer, `pk2` the
-slice `value[enc .. 2·enc]`, and `pk1` the slice `value[2·enc .. 2·enc + 64]`, where
-`enc = mlkem768Params.encapsulationKeyBytes = 1152`.  The three contractual sizes are therefore
-not bare literals but the buffer lengths *derived* from the ML-KEM-768 parameter set in
-`SrcTranslated/TypesExternal.lean` (`headerBytes = 64`, `encapsulationKeyBytes = 1152`,
-`decapsulationKeyBytes = 2400`).  `pk1`/`pk2`/`sk` carry proved `@[step]` specs recording both
-their length and their slice provenance; `from_seed` carries an `@[step]` spec fixing only the
-length of its buffer (its key derivation is not modelled).
-
 **Source**: `src/incremental_mlkem768.rs`, lines 34:0-43:1 -/
 
 open Aeneas Aeneas.Std Result
@@ -51,17 +39,12 @@ open Spqr.Mlkem
 /-- **Spec theorem for `incremental_mlkem768.generate`**:
 
 Assuming `fill_bytes` is panic-free, `generate` returns a `Keys` that is the serialization of a
-*single* compressed ML-KEM key pair `kp` — not three independent buffers of the right size.  All
+single compressed ML-KEM key pair `kp` — not three independent buffers of the right size.  All
 three outputs come, byte-for-byte, from `kp`'s one serialized buffer `kp.value`
 (`enc = encapsulationKeyBytes = 1152`):
-
-  * `dk`  = the *whole* buffer `kp.value`                 (length `2400`);
-  * `ek`  = the `t̂` sub-range `kp.value[enc .. 2·enc]`    (length `1152`);
-  * `hdr` = the header sub-range `kp.value[2·enc .. 2·enc + 64]` (length `64`).
-
-Because the model stores one shared buffer, the slice provenance is *exact* — `List.slice`
-equalities, not just length facts — mirroring the Rust accessors that slice the same `value`; the
-contractual sizes follow since `kp.value` is fixed-size.
+* `dk`  = the whole buffer `kp.value`                 (length `2400`);
+* `ek`  = the sub-range `kp.value[enc .. 2·enc]`    (length `1152`);
+* `hdr` = the header sub-range `kp.value[2·enc .. 2·enc + 64]` (length `64`).
 
 TODO: the *cryptographic* content of `kp.value` is left to future work; the size-only externals
 (`from_seed`/`encaps`/`decaps`) cannot yet state:
@@ -72,7 +55,7 @@ TODO: the *cryptographic* content of `kp.value` is left to future work; the size
    a uniform seed — the bridge that transfers security to these keys.
 3. **Security (game-based, given 2).** The KEM is IND-CCA2; `ek`/`hdr` are pseudorandom (MLWE
    hides `t̂`, safe to transmit); the secret complement `dk \ (ek‖hdr)` stays computationally
-   hidden.  Note secrecy is *not* byte-disjointness (the bytes overlap) but that the complement
+   hidden.  Note secrecy is not byte-disjointness (the bytes overlap) but that the complement
    slices stay hidden. -/
 theorem generate_spec {R : Type} (rngInst : rand.rng.Rng R)
     (cryptoInst : rand_core.CryptoRng R) (rng : R)

--- a/Spqr/Specs/IncrementalMlkem768/Generate.lean
+++ b/Spqr/Specs/IncrementalMlkem768/Generate.lean
@@ -1,0 +1,78 @@
+/-
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Spqr.Code.Funs
+import Spqr.Code.FunsExternal
+
+/-! # Spec theorem for `incremental_mlkem768::generate`
+
+`generate` draws fresh randomness, derives a compressed ML-KEM key pair via libcrux, and
+returns the three serialized buffers `(hdr, ek, dk)`.  The Rust contract is purely about the
+sizes of those buffers:
+
+```
+#[hax_lib::ensures(|result|
+  result.hdr.len() == HEADER_SIZE && result.ek.len() == ENCAPSULATION_KEY_SIZE
+  && result.dk.len() == 2400)]
+```
+
+with `HEADER_SIZE = 64` and `ENCAPSULATION_KEY_SIZE = 1152`.
+
+The libcrux routines `KeyPairCompressedBytes::{from_seed, pk1, pk2, sk}` are opaque externals
+whose return *types* already pin the array sizes (`[u8; 64]`, `[u8; 1152]`, `[u8; 2400]`); we
+only postulate that they do not panic (return `ok`), mirroring the admitted libcrux interface
+used by the hax extraction.  `RngCore::fill_bytes` is a trait method on an arbitrary `R`, so its
+non-panicking behaviour is taken as a hypothesis on the instance.  The output buffer lengths are
+then independent of the randomness: `from_slice` reconstructs a `[u8; 64]` regardless, so the
+sizes follow from the `pk1`/`pk2`/`sk` return types through `to_slice`/`to_vec`.
+
+**Source**: spqr/src/incremental_mlkem768.rs (lines 34:0-43:1) -/
+
+open Aeneas Aeneas.Std Result
+
+namespace spqr.incremental_mlkem768
+
+open libcrux_ml_kem.mlkem768.incremental
+
+/-- Trusted interface spec: `KeyPairCompressedBytes::from_seed` does not panic.  The result type
+`KeyPairCompressedBytes` carries no size obligation, so the postcondition is trivial. -/
+@[step]
+axiom from_seed_spec (x : Array Std.U8 64#usize) :
+    KeyPairCompressedBytes.from_seed x ⦃ fun _ => True ⦄
+
+/-- Trusted interface spec: `KeyPairCompressedBytes::pk1` does not panic.  Its return type
+`[u8; 64]` pins the header size. -/
+@[step]
+axiom pk1_spec (k : KeyPairCompressedBytes) :
+    KeyPairCompressedBytes.pk1 k ⦃ fun (_ : Array Std.U8 64#usize) => True ⦄
+
+/-- Trusted interface spec: `KeyPairCompressedBytes::pk2` does not panic.  Its return type
+`[u8; 1152]` pins the encapsulation-key size. -/
+@[step]
+axiom pk2_spec (k : KeyPairCompressedBytes) :
+    KeyPairCompressedBytes.pk2 k ⦃ fun (_ : Array Std.U8 1152#usize) => True ⦄
+
+/-- Trusted interface spec: `KeyPairCompressedBytes::sk` does not panic.  Its return type
+`[u8; 2400]` pins the decapsulation-key size. -/
+@[step]
+axiom sk_spec (k : KeyPairCompressedBytes) :
+    KeyPairCompressedBytes.sk k ⦃ fun (_ : Array Std.U8 2400#usize) => True ⦄
+
+/-- **Spec theorem for `incremental_mlkem768.generate`**:
+
+Assuming the RNG's `fill_bytes` does not panic, `generate` returns a `Keys` whose three buffers
+have the sizes mandated by the Rust contract: `hdr` is 64 bytes, `ek` is 1152 bytes, and `dk` is
+2400 bytes. -/
+theorem generate_spec {R : Type} (rngInst : rand.rng.Rng R)
+    (cryptoInst : rand_core.CryptoRng R) (rng : R)
+    (h_fill : ∀ (r : R) (s : Slice Std.U8),
+      rngInst.rand_coreRngCoreInst.fill_bytes r s ⦃ fun _ => True ⦄) :
+    generate rngInst cryptoInst rng ⦃ (result : Keys × R) =>
+      result.1.hdr.length = 64 ∧
+      result.1.ek.length = 1152 ∧
+      result.1.dk.length = 2400 ⦄ := by
+  unfold generate
+  step*
+
+end spqr.incremental_mlkem768

--- a/Spqr/Specs/IncrementalMlkem768/Generate.lean
+++ b/Spqr/Specs/IncrementalMlkem768/Generate.lean
@@ -18,13 +18,17 @@ sizes of those buffers:
   && result.dk.len() == 2400)]
 ```
 
-with `HEADER_SIZE = 64` and `ENCAPSULATION_KEY_SIZE = 1152`.
+with `HEADER_SIZE = 64` and `ENCAPSULATION_KEY_SIZE = 1152`.  These three sizes are not bare
+literals in the model: they are the buffer lengths *derived* from the ML-KEM-768 parameter set
+in `SrcTranslated/TypesExternal.lean` (`headerBytes = 64`,
+`mlkem768Params.encapsulationKeyBytes = 1152`, `mlkem768Params.decapsulationKeyBytes = 2400`).
 
 The libcrux routines `KeyPairCompressedBytes::{from_seed, pk1, pk2, sk}` are externals whose
 return *types* already pin the array sizes (`[u8; 64]`, `[u8; 1152]`, `[u8; 2400]`).  They are
 modelled in `SrcTranslated/FunsExternal.lean` as honest `def`s over a concrete
-`KeyPairCompressedBytes` struct, each with a proved `@[step]` spec stating only that the call
-does not panic (the cryptographic content is not modelled).
+`KeyPairCompressedBytes` struct — whose field lengths are exactly those derived sizes — each
+with a proved `@[step]` spec stating only that the call does not panic (the cryptographic
+content is not modelled).
 `RngCore::fill_bytes` is a trait method on an arbitrary `R`, so its
 non-panicking behaviour is taken as a hypothesis on the instance.  The output buffer lengths are
 then independent of the randomness: `from_slice` reconstructs a `[u8; 64]` regardless, so the
@@ -37,7 +41,7 @@ open Aeneas Aeneas.Std Result
 namespace spqr.incremental_mlkem768
 
 open libcrux_ml_kem.mlkem768.incremental
-
+open Spqr.Mlkem
 /-- **Spec theorem for `incremental_mlkem768.generate`**:
 
 - Assuming the RNG's `fill_bytes` does not panic

--- a/SrcTranslated/Funs.lean
+++ b/SrcTranslated/Funs.lean
@@ -551,7 +551,7 @@ def proto.pq_ratchet.v1_state.chunked.Ct2Sampled.Insts.CoreCloneClone.clone
   := do
   let o ←
     core.option.Option.Insts.CoreCloneClone.clone
-      proto.pq_ratchet.v1_state.unchunked.Ct2Sent.Insts.CoreCloneClone 
+      proto.pq_ratchet.v1_state.unchunked.Ct2Sent.Insts.CoreCloneClone
       self.uc
   let o1 ←
     core.option.Option.Insts.CoreCloneClone.clone
@@ -593,7 +593,7 @@ def
   := do
   let o ←
     core.option.Option.Insts.CoreCloneClone.clone
-      proto.pq_ratchet.v1_state.unchunked.Ct1Sent.Insts.CoreCloneClone 
+      proto.pq_ratchet.v1_state.unchunked.Ct1Sent.Insts.CoreCloneClone
       self.uc
   let o1 ←
     core.option.Option.Insts.CoreCloneClone.clone
@@ -652,7 +652,7 @@ def proto.pq_ratchet.v1_state.chunked.Ct1Sampled.Insts.CoreCloneClone.clone
   := do
   let o ←
     core.option.Option.Insts.CoreCloneClone.clone
-      proto.pq_ratchet.v1_state.unchunked.Ct1Sent.Insts.CoreCloneClone 
+      proto.pq_ratchet.v1_state.unchunked.Ct1Sent.Insts.CoreCloneClone
       self.uc
   let o1 ←
     core.option.Option.Insts.CoreCloneClone.clone
@@ -834,7 +834,7 @@ def proto.pq_ratchet.v1_state.chunked.HeaderSent.Insts.CoreCloneClone.clone
   := do
   let o ←
     core.option.Option.Insts.CoreCloneClone.clone
-      proto.pq_ratchet.v1_state.unchunked.EkSent.Insts.CoreCloneClone 
+      proto.pq_ratchet.v1_state.unchunked.EkSent.Insts.CoreCloneClone
       self.uc
   let o1 ←
     core.option.Option.Insts.CoreCloneClone.clone
@@ -1178,7 +1178,7 @@ def proto.pq_ratchet.Chain.Insts.CoreCmpPartialEqChain.eq
       then
         let b ←
           alloc.vec.partial_eq.PartialEqVec.eq
-            proto.pq_ratchet.chain.Epoch.Insts.CoreCmpPartialEqEpoch 
+            proto.pq_ratchet.chain.Epoch.Insts.CoreCmpPartialEqEpoch
             self.links other.links
         if b
         then
@@ -11000,7 +11000,7 @@ def v1.chunked.send_ek.KeysUnsampled.epoch
     Visibility: public -/
 def v1.unchunked.send_ek.KeysUnsampled.send_header
   {R : Type} (randrngRngInst : rand.rng.Rng R) (rand_coreCryptoRngInst :
-  rand_core.CryptoRng R) (self : v1.unchunked.send_ek.KeysUnsampled) 
+  rand_core.CryptoRng R) (self : v1.unchunked.send_ek.KeysUnsampled)
   (rng : R) :
   Result ((v1.unchunked.send_ek.HeaderSent × (alloc.vec.Vec Std.U8) ×
     (alloc.vec.Vec Std.U8)) × R)
@@ -11112,13 +11112,13 @@ def v1.chunked.send_ct.HeaderReceived.epoch
     Visibility: public -/
 def v1.unchunked.send_ct.HeaderReceived.send_ct1
   {R : Type} (randrngRngInst : rand.rng.Rng R) (rand_coreCryptoRngInst :
-  rand_core.CryptoRng R) (self : v1.unchunked.send_ct.HeaderReceived) 
+  rand_core.CryptoRng R) (self : v1.unchunked.send_ct.HeaderReceived)
   (rng : R) :
   Result ((v1.unchunked.send_ct.Ct1Sent × (alloc.vec.Vec Std.U8) ×
     EpochSecret) × R)
   := do
   let ((ct1, es, secret), rng1) ←
-    incremental_mlkem768.encaps1 randrngRngInst rand_coreCryptoRngInst 
+    incremental_mlkem768.encaps1 randrngRngInst rand_coreCryptoRngInst
       self.hdr rng
   let s ←
     lift (Array.to_slice

--- a/SrcTranslated/Funs.lean
+++ b/SrcTranslated/Funs.lean
@@ -64,6 +64,29 @@ def U32.Insts.CoreFmtDisplay : core.fmt.Display Std.U32 := {
   fmt := core.fmt.num.imp.DisplayU32.fmt
 }
 
+/-- Trait implementation: [core::iter::adapters::enumerate::{impl core::iter::traits::iterator::Iterator<(usize, Clause0_Item)> for core::iter::adapters::enumerate::Enumerate<I>}]
+    Source: '/rustc/library/core/src/iter/adapters/enumerate.rs', lines 62:0-64:16
+    Name pattern: [core::iter::traits::iterator::Iterator<core::iter::adapters::enumerate::Enumerate<@I>, (usize, @Clause0_Item)>] -/
+@[reducible, rust_trait_impl
+  "core::iter::traits::iterator::Iterator<core::iter::adapters::enumerate::Enumerate<@I>, (usize, @Clause0_Item)>"]
+def
+  core.iter.adapters.enumerate.Enumerate.Insts.CoreIterTraitsIteratorIteratorPairUsizeClause0_Item
+  {I : Type} {Clause0_Item : Type} (traitsiteratorIteratorInst :
+  core.iter.traits.iterator.Iterator I Clause0_Item) :
+  core.iter.traits.iterator.Iterator (core.iter.adapters.enumerate.Enumerate I)
+  (Std.Usize × Clause0_Item) := {
+  next :=
+    core.iter.adapters.enumerate.Enumerate.Insts.CoreIterTraitsIteratorIteratorPairUsizeClause0_Item.next
+    traitsiteratorIteratorInst
+  step_by :=
+    core.iter.adapters.enumerate.Enumerate.Insts.CoreIterTraitsIteratorIteratorPairUsizeClause0_Item.step_by
+    traitsiteratorIteratorInst
+  enumerate :=
+    core.iter.adapters.enumerate.Enumerate.Insts.CoreIterTraitsIteratorIteratorPairUsizeClause0_Item.enumerate
+    traitsiteratorIteratorInst
+  take := sorry
+}
+
 /-- Trait implementation: [core::iter::range::{impl core::iter::range::Step for i32}]
     Source: '/rustc/library/core/src/iter/range.rs', lines 301:12-301:43
     Name pattern: [core::iter::range::Step<i32>] -/
@@ -5425,8 +5448,8 @@ def chain.ChainEpochDirection.next_key
   Result ((Std.U32 × (alloc.vec.Vec Std.U8)) × chain.ChainEpochDirection)
   := do
   let (s, deref_mut_back) ← lift (alloc.vec.Vec.deref_mut self.next)
-  let ((idx, key), s1, i) ←
-    chain.ChainEpochDirection.next_key_internal s self.ctr
+  let (p, s1, i) ← chain.ChainEpochDirection.next_key_internal s self.ctr
+  let (idx, key) := p
   let s2 ← lift (Array.to_slice key)
   let v ← alloc.slice.Slice.to_vec core.clone.CloneU8 s2
   let v1 := deref_mut_back s1
@@ -5501,7 +5524,8 @@ def chain.ChainEpochDirection.key
         chain.ChainEpochDirection.key_loop self.ctr self.next kh at1 params
       let kh2 ← chain.KeyHistory.gc kh1 i4 params
       let (s, deref_mut_back) ← lift (alloc.vec.Vec.deref_mut v)
-      let ((_, a), s1, i5) ← chain.ChainEpochDirection.next_key_internal s i4
+      let (p, s1, i5) ← chain.ChainEpochDirection.next_key_internal s i4
+      let (_, a) := p
       let s2 ← lift (Array.to_slice a)
       let v1 ← alloc.slice.Slice.to_vec core.clone.CloneU8 s2
       let v2 := deref_mut_back s1
@@ -7157,7 +7181,8 @@ def encoding.polynomial.Poly.lagrange_interpolate_complete
   := do
   let pi ← Slice.index_usize pts i
   let iter ←
-    SharedSlice.Insts.CoreIterTraitsCollectIntoIteratorSharedIter.into_iter pts
+    SharedASlice.Insts.CoreIterTraitsCollectIntoIteratorSharedATIter.into_iter
+      pts
   let (pi1, denominator) ←
     encoding.polynomial.Poly.lagrange_interpolate_complete_loop0 iter pi
       encoding.gf.GF16.ONE
@@ -7435,7 +7460,7 @@ def encoding.polynomial.Poly.add_assign_loop.body
     encoding.polynomial.Poly)
   := do
   let (o, iter1) ←
-    core.iter.adapters.enumerate.IteratorEnumerate.next
+    core.iter.adapters.enumerate.Enumerate.Insts.CoreIterTraitsIteratorIteratorPairUsizeClause0_Item.next
       (core.iter.traits.iterator.IteratorSliceIter encoding.gf.GF16) iter
   match o with
   | none => ok (done self)
@@ -8036,7 +8061,7 @@ def encoding.polynomial.Poly.from_complete_points_loop.body
     encoding.polynomial.Poly Unit))
   := do
   let (o, iter1) ←
-    core.iter.adapters.enumerate.IteratorEnumerate.next
+    core.iter.adapters.enumerate.Enumerate.Insts.CoreIterTraitsIteratorIteratorPairUsizeClause0_Item.next
       (core.iter.traits.iterator.IteratorSliceIter encoding.polynomial.Pt) iter
   match o with
   | none =>
@@ -8758,7 +8783,7 @@ def encoding.polynomial.PolyEncoder.point_at_loop.body
         e ()
     let pt_vec ←
       core.iter.adapters.map.Map.Insts.CoreIterTraitsIteratorIterator.collect
-        (core.iter.traits.iterator.IteratorEnumerate
+        (core.iter.adapters.enumerate.Enumerate.Insts.CoreIterTraitsIteratorIteratorPairUsizeClause0_Item
         (core.iter.traits.iterator.IteratorSliceIter encoding.gf.GF16))
         encoding.polynomial.PolyEncoder.point_at.closure_1.Insts.CoreOpsFunctionFnMutTuplePairUsizeSharedGF16Pt
         (core.iter.traits.collect.FromIteratorVec encoding.polynomial.Pt) m
@@ -8908,7 +8933,7 @@ def encoding.polynomial.PolyEncoder.encode_bytes_base_loop.body
     16#usize)) (Array encoding.polynomial.Point 16#usize))
   := do
   let (o, iter1) ←
-    core.iter.adapters.enumerate.IteratorEnumerate.next
+    core.iter.adapters.enumerate.Enumerate.Insts.CoreIterTraitsIteratorIteratorPairUsizeClause0_Item.next
       (core.iter.traits.iterator.IteratorChunksExact Std.U8) iter
   match o with
   | none => ok (done pts)
@@ -11021,9 +11046,10 @@ def v1.chunked.send_ek.KeysUnsampled.send_hdr_chunk
   rand_core.CryptoRng R) (self : v1.chunked.send_ek.KeysUnsampled) (rng : R) :
   Result ((v1.chunked.send_ek.KeysSampled × encoding.Chunk) × R)
   := do
-  let ((uc, to_send, mac), rng1) ←
+  let (t, rng1) ←
     v1.unchunked.send_ek.KeysUnsampled.send_header randrngRngInst
       rand_coreCryptoRngInst self.uc rng
+  let (uc, to_send, mac) := t
   let (to_send1, _) ← alloc.vec.Vec.append Global to_send mac
   let s := alloc.vec.Vec.deref to_send1
   let encoder ←
@@ -11117,9 +11143,10 @@ def v1.unchunked.send_ct.HeaderReceived.send_ct1
   Result ((v1.unchunked.send_ct.Ct1Sent × (alloc.vec.Vec Std.U8) ×
     EpochSecret) × R)
   := do
-  let ((ct1, es, secret), rng1) ←
+  let (t, rng1) ←
     incremental_mlkem768.encaps1 randrngRngInst rand_coreCryptoRngInst
       self.hdr rng
+  let (ct1, es, secret) := t
   let s ←
     lift (Array.to_slice
       (Array.make 33#usize [
@@ -11154,9 +11181,10 @@ def v1.chunked.send_ct.HeaderReceived.send_ct1_chunk
   Result ((v1.chunked.send_ct.Ct1Sampled × encoding.Chunk × EpochSecret) ×
     R)
   := do
-  let ((uc, ct1, epoch_secret), rng1) ←
+  let (t, rng1) ←
     v1.unchunked.send_ct.HeaderReceived.send_ct1 randrngRngInst
       rand_coreCryptoRngInst self.uc rng
+  let (uc, ct1, epoch_secret) := t
   let s := alloc.vec.Vec.deref ct1
   let encoder ←
     encoding.polynomial.PolyEncoder.Insts.SpqrEncodingEncoder.encode_bytes s
@@ -11186,9 +11214,10 @@ def v1.chunked.states.States.send
   match self with
   | v1.chunked.states.States.KeysUnsampled state =>
     let epoch ← v1.chunked.send_ek.KeysUnsampled.epoch state
-    let ((state1, chunk), rng1) ←
+    let (p, rng1) ←
       v1.chunked.send_ek.KeysUnsampled.send_hdr_chunk randrngRngInst
         rand_coreCryptoRngInst state rng
+    let (state1, chunk) := p
     ok (core.result.Result.Ok
       {
         msg :=
@@ -11246,9 +11275,10 @@ def v1.chunked.states.States.send
       }, rng)
   | v1.chunked.states.States.HeaderReceived state =>
     let epoch ← v1.chunked.send_ct.HeaderReceived.epoch state
-    let ((state1, chunk, epoch_secret), rng1) ←
+    let (t, rng1) ←
       v1.chunked.send_ct.HeaderReceived.send_ct1_chunk randrngRngInst
         rand_coreCryptoRngInst state rng
+    let (state1, chunk, epoch_secret) := t
     ok (core.result.Result.Ok
       {
         msg :=

--- a/SrcTranslated/Funs.lean
+++ b/SrcTranslated/Funs.lean
@@ -64,29 +64,6 @@ def U32.Insts.CoreFmtDisplay : core.fmt.Display Std.U32 := {
   fmt := core.fmt.num.imp.DisplayU32.fmt
 }
 
-/-- Trait implementation: [core::iter::adapters::enumerate::{impl core::iter::traits::iterator::Iterator<(usize, Clause0_Item)> for core::iter::adapters::enumerate::Enumerate<I>}]
-    Source: '/rustc/library/core/src/iter/adapters/enumerate.rs', lines 62:0-64:16
-    Name pattern: [core::iter::traits::iterator::Iterator<core::iter::adapters::enumerate::Enumerate<@I>, (usize, @Clause0_Item)>] -/
-@[reducible, rust_trait_impl
-  "core::iter::traits::iterator::Iterator<core::iter::adapters::enumerate::Enumerate<@I>, (usize, @Clause0_Item)>"]
-def
-  core.iter.adapters.enumerate.Enumerate.Insts.CoreIterTraitsIteratorIteratorPairUsizeClause0_Item
-  {I : Type} {Clause0_Item : Type} (traitsiteratorIteratorInst :
-  core.iter.traits.iterator.Iterator I Clause0_Item) :
-  core.iter.traits.iterator.Iterator (core.iter.adapters.enumerate.Enumerate I)
-  (Std.Usize × Clause0_Item) := {
-  next :=
-    core.iter.adapters.enumerate.Enumerate.Insts.CoreIterTraitsIteratorIteratorPairUsizeClause0_Item.next
-    traitsiteratorIteratorInst
-  step_by :=
-    core.iter.adapters.enumerate.Enumerate.Insts.CoreIterTraitsIteratorIteratorPairUsizeClause0_Item.step_by
-    traitsiteratorIteratorInst
-  enumerate :=
-    core.iter.adapters.enumerate.Enumerate.Insts.CoreIterTraitsIteratorIteratorPairUsizeClause0_Item.enumerate
-    traitsiteratorIteratorInst
-  take := sorry
-}
-
 /-- Trait implementation: [core::iter::range::{impl core::iter::range::Step for i32}]
     Source: '/rustc/library/core/src/iter/range.rs', lines 301:12-301:43
     Name pattern: [core::iter::range::Step<i32>] -/
@@ -5448,8 +5425,8 @@ def chain.ChainEpochDirection.next_key
   Result ((Std.U32 × (alloc.vec.Vec Std.U8)) × chain.ChainEpochDirection)
   := do
   let (s, deref_mut_back) ← lift (alloc.vec.Vec.deref_mut self.next)
-  let (p, s1, i) ← chain.ChainEpochDirection.next_key_internal s self.ctr
-  let (idx, key) := p
+  let ((idx, key), s1, i) ←
+    chain.ChainEpochDirection.next_key_internal s self.ctr
   let s2 ← lift (Array.to_slice key)
   let v ← alloc.slice.Slice.to_vec core.clone.CloneU8 s2
   let v1 := deref_mut_back s1
@@ -5524,8 +5501,7 @@ def chain.ChainEpochDirection.key
         chain.ChainEpochDirection.key_loop self.ctr self.next kh at1 params
       let kh2 ← chain.KeyHistory.gc kh1 i4 params
       let (s, deref_mut_back) ← lift (alloc.vec.Vec.deref_mut v)
-      let (p, s1, i5) ← chain.ChainEpochDirection.next_key_internal s i4
-      let (_, a) := p
+      let ((_, a), s1, i5) ← chain.ChainEpochDirection.next_key_internal s i4
       let s2 ← lift (Array.to_slice a)
       let v1 ← alloc.slice.Slice.to_vec core.clone.CloneU8 s2
       let v2 := deref_mut_back s1
@@ -7181,8 +7157,7 @@ def encoding.polynomial.Poly.lagrange_interpolate_complete
   := do
   let pi ← Slice.index_usize pts i
   let iter ←
-    SharedASlice.Insts.CoreIterTraitsCollectIntoIteratorSharedATIter.into_iter
-      pts
+    SharedSlice.Insts.CoreIterTraitsCollectIntoIteratorSharedIter.into_iter pts
   let (pi1, denominator) ←
     encoding.polynomial.Poly.lagrange_interpolate_complete_loop0 iter pi
       encoding.gf.GF16.ONE
@@ -7460,7 +7435,7 @@ def encoding.polynomial.Poly.add_assign_loop.body
     encoding.polynomial.Poly)
   := do
   let (o, iter1) ←
-    core.iter.adapters.enumerate.Enumerate.Insts.CoreIterTraitsIteratorIteratorPairUsizeClause0_Item.next
+    core.iter.adapters.enumerate.IteratorEnumerate.next
       (core.iter.traits.iterator.IteratorSliceIter encoding.gf.GF16) iter
   match o with
   | none => ok (done self)
@@ -8061,7 +8036,7 @@ def encoding.polynomial.Poly.from_complete_points_loop.body
     encoding.polynomial.Poly Unit))
   := do
   let (o, iter1) ←
-    core.iter.adapters.enumerate.Enumerate.Insts.CoreIterTraitsIteratorIteratorPairUsizeClause0_Item.next
+    core.iter.adapters.enumerate.IteratorEnumerate.next
       (core.iter.traits.iterator.IteratorSliceIter encoding.polynomial.Pt) iter
   match o with
   | none =>
@@ -8783,7 +8758,7 @@ def encoding.polynomial.PolyEncoder.point_at_loop.body
         e ()
     let pt_vec ←
       core.iter.adapters.map.Map.Insts.CoreIterTraitsIteratorIterator.collect
-        (core.iter.adapters.enumerate.Enumerate.Insts.CoreIterTraitsIteratorIteratorPairUsizeClause0_Item
+        (core.iter.traits.iterator.IteratorEnumerate
         (core.iter.traits.iterator.IteratorSliceIter encoding.gf.GF16))
         encoding.polynomial.PolyEncoder.point_at.closure_1.Insts.CoreOpsFunctionFnMutTuplePairUsizeSharedGF16Pt
         (core.iter.traits.collect.FromIteratorVec encoding.polynomial.Pt) m
@@ -8933,7 +8908,7 @@ def encoding.polynomial.PolyEncoder.encode_bytes_base_loop.body
     16#usize)) (Array encoding.polynomial.Point 16#usize))
   := do
   let (o, iter1) ←
-    core.iter.adapters.enumerate.Enumerate.Insts.CoreIterTraitsIteratorIteratorPairUsizeClause0_Item.next
+    core.iter.adapters.enumerate.IteratorEnumerate.next
       (core.iter.traits.iterator.IteratorChunksExact Std.U8) iter
   match o with
   | none => ok (done pts)
@@ -11046,10 +11021,9 @@ def v1.chunked.send_ek.KeysUnsampled.send_hdr_chunk
   rand_core.CryptoRng R) (self : v1.chunked.send_ek.KeysUnsampled) (rng : R) :
   Result ((v1.chunked.send_ek.KeysSampled × encoding.Chunk) × R)
   := do
-  let (t, rng1) ←
+  let ((uc, to_send, mac), rng1) ←
     v1.unchunked.send_ek.KeysUnsampled.send_header randrngRngInst
       rand_coreCryptoRngInst self.uc rng
-  let (uc, to_send, mac) := t
   let (to_send1, _) ← alloc.vec.Vec.append Global to_send mac
   let s := alloc.vec.Vec.deref to_send1
   let encoder ←
@@ -11143,10 +11117,9 @@ def v1.unchunked.send_ct.HeaderReceived.send_ct1
   Result ((v1.unchunked.send_ct.Ct1Sent × (alloc.vec.Vec Std.U8) ×
     EpochSecret) × R)
   := do
-  let (t, rng1) ←
+  let ((ct1, es, secret), rng1) ←
     incremental_mlkem768.encaps1 randrngRngInst rand_coreCryptoRngInst
       self.hdr rng
-  let (ct1, es, secret) := t
   let s ←
     lift (Array.to_slice
       (Array.make 33#usize [
@@ -11181,10 +11154,9 @@ def v1.chunked.send_ct.HeaderReceived.send_ct1_chunk
   Result ((v1.chunked.send_ct.Ct1Sampled × encoding.Chunk × EpochSecret) ×
     R)
   := do
-  let (t, rng1) ←
+  let ((uc, ct1, epoch_secret), rng1) ←
     v1.unchunked.send_ct.HeaderReceived.send_ct1 randrngRngInst
       rand_coreCryptoRngInst self.uc rng
-  let (uc, ct1, epoch_secret) := t
   let s := alloc.vec.Vec.deref ct1
   let encoder ←
     encoding.polynomial.PolyEncoder.Insts.SpqrEncodingEncoder.encode_bytes s
@@ -11214,10 +11186,9 @@ def v1.chunked.states.States.send
   match self with
   | v1.chunked.states.States.KeysUnsampled state =>
     let epoch ← v1.chunked.send_ek.KeysUnsampled.epoch state
-    let (p, rng1) ←
+    let ((state1, chunk), rng1) ←
       v1.chunked.send_ek.KeysUnsampled.send_hdr_chunk randrngRngInst
         rand_coreCryptoRngInst state rng
-    let (state1, chunk) := p
     ok (core.result.Result.Ok
       {
         msg :=
@@ -11275,10 +11246,9 @@ def v1.chunked.states.States.send
       }, rng)
   | v1.chunked.states.States.HeaderReceived state =>
     let epoch ← v1.chunked.send_ct.HeaderReceived.epoch state
-    let (t, rng1) ←
+    let ((state1, chunk, epoch_secret), rng1) ←
       v1.chunked.send_ct.HeaderReceived.send_ct1_chunk randrngRngInst
         rand_coreCryptoRngInst state rng
-    let (state1, chunk, epoch_secret) := t
     ok (core.result.Result.Ok
       {
         msg :=

--- a/SrcTranslated/Funs.lean
+++ b/SrcTranslated/Funs.lean
@@ -551,7 +551,7 @@ def proto.pq_ratchet.v1_state.chunked.Ct2Sampled.Insts.CoreCloneClone.clone
   := do
   let o ←
     core.option.Option.Insts.CoreCloneClone.clone
-      proto.pq_ratchet.v1_state.unchunked.Ct2Sent.Insts.CoreCloneClone
+      proto.pq_ratchet.v1_state.unchunked.Ct2Sent.Insts.CoreCloneClone 
       self.uc
   let o1 ←
     core.option.Option.Insts.CoreCloneClone.clone
@@ -593,7 +593,7 @@ def
   := do
   let o ←
     core.option.Option.Insts.CoreCloneClone.clone
-      proto.pq_ratchet.v1_state.unchunked.Ct1Sent.Insts.CoreCloneClone
+      proto.pq_ratchet.v1_state.unchunked.Ct1Sent.Insts.CoreCloneClone 
       self.uc
   let o1 ←
     core.option.Option.Insts.CoreCloneClone.clone
@@ -652,7 +652,7 @@ def proto.pq_ratchet.v1_state.chunked.Ct1Sampled.Insts.CoreCloneClone.clone
   := do
   let o ←
     core.option.Option.Insts.CoreCloneClone.clone
-      proto.pq_ratchet.v1_state.unchunked.Ct1Sent.Insts.CoreCloneClone
+      proto.pq_ratchet.v1_state.unchunked.Ct1Sent.Insts.CoreCloneClone 
       self.uc
   let o1 ←
     core.option.Option.Insts.CoreCloneClone.clone
@@ -834,7 +834,7 @@ def proto.pq_ratchet.v1_state.chunked.HeaderSent.Insts.CoreCloneClone.clone
   := do
   let o ←
     core.option.Option.Insts.CoreCloneClone.clone
-      proto.pq_ratchet.v1_state.unchunked.EkSent.Insts.CoreCloneClone
+      proto.pq_ratchet.v1_state.unchunked.EkSent.Insts.CoreCloneClone 
       self.uc
   let o1 ←
     core.option.Option.Insts.CoreCloneClone.clone
@@ -1178,7 +1178,7 @@ def proto.pq_ratchet.Chain.Insts.CoreCmpPartialEqChain.eq
       then
         let b ←
           alloc.vec.partial_eq.PartialEqVec.eq
-            proto.pq_ratchet.chain.Epoch.Insts.CoreCmpPartialEqEpoch
+            proto.pq_ratchet.chain.Epoch.Insts.CoreCmpPartialEqEpoch 
             self.links other.links
         if b
         then
@@ -11000,7 +11000,7 @@ def v1.chunked.send_ek.KeysUnsampled.epoch
     Visibility: public -/
 def v1.unchunked.send_ek.KeysUnsampled.send_header
   {R : Type} (randrngRngInst : rand.rng.Rng R) (rand_coreCryptoRngInst :
-  rand_core.CryptoRng R) (self : v1.unchunked.send_ek.KeysUnsampled)
+  rand_core.CryptoRng R) (self : v1.unchunked.send_ek.KeysUnsampled) 
   (rng : R) :
   Result ((v1.unchunked.send_ek.HeaderSent × (alloc.vec.Vec Std.U8) ×
     (alloc.vec.Vec Std.U8)) × R)
@@ -11112,13 +11112,13 @@ def v1.chunked.send_ct.HeaderReceived.epoch
     Visibility: public -/
 def v1.unchunked.send_ct.HeaderReceived.send_ct1
   {R : Type} (randrngRngInst : rand.rng.Rng R) (rand_coreCryptoRngInst :
-  rand_core.CryptoRng R) (self : v1.unchunked.send_ct.HeaderReceived)
+  rand_core.CryptoRng R) (self : v1.unchunked.send_ct.HeaderReceived) 
   (rng : R) :
   Result ((v1.unchunked.send_ct.Ct1Sent × (alloc.vec.Vec Std.U8) ×
     EpochSecret) × R)
   := do
   let ((ct1, es, secret), rng1) ←
-    incremental_mlkem768.encaps1 randrngRngInst rand_coreCryptoRngInst
+    incremental_mlkem768.encaps1 randrngRngInst rand_coreCryptoRngInst 
       self.hdr rng
   let s ←
     lift (Array.to_slice

--- a/SrcTranslated/FunsExternal.lean
+++ b/SrcTranslated/FunsExternal.lean
@@ -1573,45 +1573,27 @@ expressed here through the parameter-derived constants rather than bare literals
 
 These are exactly what callers (`generate`) rely on for their own size contract.
 
-**(3) Layout containment: `pk1` and `pk2` fit inside the full `sk` serialization.**
-Because `sk()` returns the entire `value` while `pk1()`/`pk2()` are *sub-ranges* of that
-same buffer, each public buffer is no longer than `sk`, and — being disjoint ranges of
-it (`pk2` = `[RBPRE, 2·RBPRE)`, `pk1` = `[2·RBPRE, 2·RBPRE + 64)`) — they fit inside `sk`
-together.  This records the in-bounds facts a caller needs to justify copying `pk1`/`pk2`
-out of the `sk` serialization, and follows arithmetically from (2):
-`64 + 1152 ≤ 2400`.
+**(3) Layout: `from_seed` produces the single `value` buffer.**  In this faithful
+single-buffer model, `from_seed` returns a `KeyPairCompressedBytes` holding the whole
+serialized buffer `value`, of size `mlkem768Params.decapsulationKeyBytes = 2400` (Rust
+`key_pair_compressed_len() = SECRET_KEY_SIZE`).  The fact that the public accessors
+`pk1`/`pk2` are byte-for-byte *sub-ranges* of `sk` (= the whole `value`) is now
+*definitional* — it lives in the accessor models `pk1`/`pk2`/`sk` below, where each is a
+literal `List.slice` of this same `value` — so it need not (and should not) be restated
+here.  The only thing `from_seed` itself must guarantee its callers is that this buffer
+has the mandated size.
 
 **Minimality.**  Nothing is claimed about the *cryptographic content* of the key pair:
 `from_seed` is an external whose key derivation is not modelled (the Lean stub returns a
-default struct), so the only honest guarantees are the structural ones above — and in
+default struct), so the only honest guarantee is the structural size one above — and in
 particular this spec deliberately does *not* assert any seed→key functional behaviour. -/
 @[step]
-theorem libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.from_seed_spec
+axiom libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.from_seed_spec
     (seed : Array Std.U8 64#usize) :
     libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.from_seed seed
       ⦃ fun kp =>
-          -- (2) exact sizes mandated by the ML-KEM-768 parameter set
-          kp.pk1Bytes.length = headerBytes ∧
-          kp.pk2Bytes.length = mlkem768Params.encapsulationKeyBytes ∧
-          kp.skBytes.length  = mlkem768Params.decapsulationKeyBytes ∧
-          -- (3) `pk1`/`pk2` are sub-ranges of the full `sk` serialization, so each fits …
-          kp.pk1Bytes.length ≤ kp.skBytes.length ∧
-          kp.pk2Bytes.length ≤ kp.skBytes.length ∧
-          -- … and, being disjoint sub-ranges, the two public buffers fit together inside `sk`
-          kp.pk1Bytes.length + kp.pk2Bytes.length ≤ kp.skBytes.length ⦄ := by
-  simp only [libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.from_seed,
-    WP.spec_ok]
-  have e1 : (default : libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes).pk1Bytes.length
-      = headerBytes := Array.length_eq _
-  have e2 : (default : libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes).pk2Bytes.length
-      = mlkem768Params.encapsulationKeyBytes := Array.length_eq _
-  have e3 : (default : libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes).skBytes.length
-      = mlkem768Params.decapsulationKeyBytes := Array.length_eq _
-  refine ⟨e1, e2, e3, ?_, ?_, ?_⟩ <;>
-    simp only [e1, e2, e3, headerBytes, seedBytes, mlkem768Params,
-      MlkemParams.encapsulationKeyBytes, MlkemParams.serializedPolyBytes,
-      MlkemParams.decapsulationKeyBytes] <;>
-    decide
+          -- (2) the single serialized buffer has the size mandated by the parameter set
+          kp.value.length = mlkem768Params.decapsulationKeyBytes ⦄
 
 /-- [libcrux_ml_kem::mlkem768::incremental::{libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes}::pk1]:
     Source: '/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libcrux-ml-kem-0.0.7/src/mlkem.rs', lines 267:12-267:49
@@ -1621,17 +1603,35 @@ theorem libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.from_seed_spe
 def libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk1
   (k : libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes) :
   Result (Array Std.U8 64#usize) :=
-  ok k.pk1Bytes
+  -- Rust: `const START = 2 * RANKED_BYTES_PER_RING_ELEMENT; value[START .. START + pk1_len()]`,
+  -- i.e. the header sub-range `value[2·enc .. 2·enc + 64]` of the shared buffer.
+  ok (Array.make 64#usize
+    (k.value.val.slice
+      (2 * mlkem768Params.encapsulationKeyBytes)
+      (2 * mlkem768Params.encapsulationKeyBytes + headerBytes))
+    (by
+      have h : k.value.val.length = mlkem768Params.decapsulationKeyBytes := Array.length_eq _
+      simp only [List.slice_length, h, headerBytes, seedBytes, mlkem768Params,
+        MlkemParams.encapsulationKeyBytes, MlkemParams.serializedPolyBytes,
+        MlkemParams.decapsulationKeyBytes]
+      decide))
 
 /-- **Spec theorem for `KeyPairCompressedBytes::pk1`**: extracting the header buffer does
-not panic and returns exactly the stored `pk1` buffer (whose return type `[u8; 64]` pins
-the header size). -/
+not panic and returns exactly the header sub-range of the shared `value` buffer, i.e. the
+`64` bytes `value[2·enc .. 2·enc + 64]` (with `enc = encapsulationKeyBytes`).  The second
+conjunct is the *faithful layout fact*: `pk1` is a byte-for-byte slice of the buffer that
+`sk` returns whole — not merely a buffer of the right size. -/
 @[step]
 theorem libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk1_spec
     (k : libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes) :
     libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk1 k
-      ⦃ fun (r : Array Std.U8 64#usize) => r = k.pk1Bytes ⦄ := by
-  simp [libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk1]
+      ⦃ fun (r : Array Std.U8 64#usize) =>
+          r.length = headerBytes ∧
+          r.val = k.value.val.slice
+            (2 * mlkem768Params.encapsulationKeyBytes)
+            (2 * mlkem768Params.encapsulationKeyBytes + headerBytes) ⦄ := by
+  simp only [libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk1, WP.spec_ok]
+  exact ⟨Array.length_eq _, rfl⟩
 
 /-- [libcrux_ml_kem::mlkem768::incremental::{libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes}::pk2]:
     Source: '/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libcrux-ml-kem-0.0.7/src/mlkem.rs', lines 275:12-275:49
@@ -1641,17 +1641,35 @@ theorem libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk1_spec
 def libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk2
   (k : libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes) :
   Result (Array Std.U8 1152#usize) :=
-  ok k.pk2Bytes
+  -- Rust: `const START = RANKED_BYTES_PER_RING_ELEMENT; value[START .. START + pk2_len()]`,
+  -- i.e. the `t̂` sub-range `value[enc .. 2·enc]` of the shared buffer.
+  ok (Array.make 1152#usize
+    (k.value.val.slice
+      mlkem768Params.encapsulationKeyBytes
+      (2 * mlkem768Params.encapsulationKeyBytes))
+    (by
+      have h : k.value.val.length = mlkem768Params.decapsulationKeyBytes := Array.length_eq _
+      simp only [List.slice_length, h, seedBytes, mlkem768Params,
+        MlkemParams.encapsulationKeyBytes, MlkemParams.serializedPolyBytes,
+        MlkemParams.decapsulationKeyBytes]
+      decide))
 
 /-- **Spec theorem for `KeyPairCompressedBytes::pk2`**: extracting the encapsulation-key
-buffer does not panic and returns exactly the stored `pk2` buffer (whose return type
-`[u8; 1152]` pins the encapsulation-key size). -/
+buffer does not panic and returns exactly the `t̂` sub-range of the shared `value` buffer,
+i.e. the `1152` bytes `value[enc .. 2·enc]` (with `enc = encapsulationKeyBytes`).  The
+second conjunct is the *faithful layout fact*: `pk2` is a byte-for-byte slice of the buffer
+that `sk` returns whole — not merely a buffer of the right size. -/
 @[step]
 theorem libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk2_spec
     (k : libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes) :
     libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk2 k
-      ⦃ fun (r : Array Std.U8 1152#usize) => r = k.pk2Bytes ⦄ := by
-  simp [libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk2]
+      ⦃ fun (r : Array Std.U8 1152#usize) =>
+          r.length = mlkem768Params.encapsulationKeyBytes ∧
+          r.val = k.value.val.slice
+            mlkem768Params.encapsulationKeyBytes
+            (2 * mlkem768Params.encapsulationKeyBytes) ⦄ := by
+  simp only [libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk2, WP.spec_ok]
+  exact ⟨Array.length_eq _, rfl⟩
 
 /-- [libcrux_ml_kem::mlkem768::incremental::{libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes}::sk]:
     Source: '/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libcrux-ml-kem-0.0.7/src/mlkem.rs', lines 283:12-283:54
@@ -1661,17 +1679,22 @@ theorem libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk2_spec
 def libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.sk
   (k : libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes) :
   Result (Array Std.U8 2400#usize) :=
-  ok k.skBytes
+  -- Rust: `sk(&self) -> &[u8; SECRET_KEY_SIZE] { &self.value }` — the *whole* buffer.
+  ok k.value
 
 /-- **Spec theorem for `KeyPairCompressedBytes::sk`**: extracting the decapsulation-key
-buffer does not panic and returns exactly the stored `sk` buffer (whose return type
-`[u8; 2400]` pins the decapsulation-key size). -/
+buffer does not panic and returns the *entire* shared `value` buffer (whose return type
+`[u8; 2400]` pins the decapsulation-key size).  Because `sk` returns `value` whole while
+`pk1`/`pk2` are slices of that same `value`, this is the buffer of which the two public
+keys are sub-ranges. -/
 @[step]
 theorem libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.sk_spec
     (k : libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes) :
     libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.sk k
-      ⦃ fun (r : Array Std.U8 2400#usize) => r = k.skBytes ⦄ := by
-  simp [libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.sk]
+      ⦃ fun (r : Array Std.U8 2400#usize) =>
+          r.length = mlkem768Params.decapsulationKeyBytes ∧ r.val = k.value.val ⦄ := by
+  simp only [libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.sk, WP.spec_ok]
+  exact ⟨Array.length_eq _, trivial⟩
 
 /-- [libcrux_ml_kem::mlkem768::incremental::validate_pk_bytes]:
     Source: '/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libcrux-ml-kem-0.0.7/src/mlkem.rs', lines 333:8-336:30

--- a/SrcTranslated/FunsExternal.lean
+++ b/SrcTranslated/FunsExternal.lean
@@ -1616,6 +1616,7 @@ def libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk1
         MlkemParams.decapsulationKeyBytes]
       decide))
 
+
 /-- **Spec theorem for `KeyPairCompressedBytes::pk1`**: extracting the header buffer does
 not panic and returns exactly the header sub-range of the shared `value` buffer, i.e. the
 `64` bytes `value[2·enc .. 2·enc + 64]` (with `enc = encapsulationKeyBytes`).  The second

--- a/SrcTranslated/FunsExternal.lean
+++ b/SrcTranslated/FunsExternal.lean
@@ -1526,40 +1526,78 @@ axiom libcrux_ml_kem.mlkem768.incremental.encapsulate2
     Name pattern: [libcrux_ml_kem::mlkem768::incremental::{libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes}::from_seed] -/
 @[rust_fun
   "libcrux_ml_kem::mlkem768::incremental::{libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes}::from_seed"]
-axiom libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.from_seed
-  :
-  Array Std.U8 64#usize → Result
-    libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes
+def libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.from_seed
+  (_seed : Array Std.U8 64#usize) : Result
+    libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes :=
+  ok default
+
+/-- **Spec theorem for `KeyPairCompressedBytes::from_seed`**: deriving the compressed
+key pair from a seed does not panic.  The result type `KeyPairCompressedBytes` carries
+no size obligation, so the postcondition is trivial; the cryptographic content of the
+key pair is not modelled. -/
+@[step]
+theorem libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.from_seed_spec
+    (seed : Array Std.U8 64#usize) :
+    libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.from_seed seed
+      ⦃ fun _ => True ⦄ := by
+  simp [libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.from_seed]
 
 /-- [libcrux_ml_kem::mlkem768::incremental::{libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes}::pk1]:
     Source: '/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libcrux-ml-kem-0.0.7/src/mlkem.rs', lines 267:12-267:49
     Name pattern: [libcrux_ml_kem::mlkem768::incremental::{libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes}::pk1] -/
 @[rust_fun
   "libcrux_ml_kem::mlkem768::incremental::{libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes}::pk1"]
-axiom libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk1
-  :
-  libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes → Result (Array
-    Std.U8 64#usize)
+def libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk1
+  (k : libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes) :
+  Result (Array Std.U8 64#usize) :=
+  ok k.pk1Bytes
+
+/-- **Spec theorem for `KeyPairCompressedBytes::pk1`**: extracting the header buffer
+does not panic.  Its return type `[u8; 64]` pins the header size. -/
+@[step]
+theorem libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk1_spec
+    (k : libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes) :
+    libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk1 k
+      ⦃ fun (_ : Array Std.U8 64#usize) => True ⦄ := by
+  simp [libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk1]
 
 /-- [libcrux_ml_kem::mlkem768::incremental::{libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes}::pk2]:
     Source: '/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libcrux-ml-kem-0.0.7/src/mlkem.rs', lines 275:12-275:49
     Name pattern: [libcrux_ml_kem::mlkem768::incremental::{libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes}::pk2] -/
 @[rust_fun
   "libcrux_ml_kem::mlkem768::incremental::{libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes}::pk2"]
-axiom libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk2
-  :
-  libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes → Result (Array
-    Std.U8 1152#usize)
+def libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk2
+  (k : libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes) :
+  Result (Array Std.U8 1152#usize) :=
+  ok k.pk2Bytes
+
+/-- **Spec theorem for `KeyPairCompressedBytes::pk2`**: extracting the encapsulation-key
+buffer does not panic.  Its return type `[u8; 1152]` pins the encapsulation-key size. -/
+@[step]
+theorem libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk2_spec
+    (k : libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes) :
+    libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk2 k
+      ⦃ fun (_ : Array Std.U8 1152#usize) => True ⦄ := by
+  simp [libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk2]
 
 /-- [libcrux_ml_kem::mlkem768::incremental::{libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes}::sk]:
     Source: '/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libcrux-ml-kem-0.0.7/src/mlkem.rs', lines 283:12-283:54
     Name pattern: [libcrux_ml_kem::mlkem768::incremental::{libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes}::sk] -/
 @[rust_fun
   "libcrux_ml_kem::mlkem768::incremental::{libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes}::sk"]
-axiom libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.sk
-  :
-  libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes → Result (Array
-    Std.U8 2400#usize)
+def libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.sk
+  (k : libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes) :
+  Result (Array Std.U8 2400#usize) :=
+  ok k.skBytes
+
+/-- **Spec theorem for `KeyPairCompressedBytes::sk`**: extracting the decapsulation-key
+buffer does not panic.  Its return type `[u8; 2400]` pins the decapsulation-key size. -/
+@[step]
+theorem libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.sk_spec
+    (k : libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes) :
+    libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.sk k
+      ⦃ fun (_ : Array Std.U8 2400#usize) => True ⦄ := by
+  simp [libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.sk]
 
 /-- [libcrux_ml_kem::mlkem768::incremental::validate_pk_bytes]:
     Source: '/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libcrux-ml-kem-0.0.7/src/mlkem.rs', lines 333:8-336:30

--- a/SrcTranslated/FunsExternal.lean
+++ b/SrcTranslated/FunsExternal.lean
@@ -14,6 +14,7 @@ set_option linter.style.whitespace false
 /- You can set the `maxHeartbeats` value with the `-max-heartbeats` CLI option -/
 set_option maxHeartbeats 1000000
 open spqr
+open Spqr.Mlkem
 
 /-- [core::cmp::impls::{impl core::cmp::Eq for u8}::assert_fields_are_eq]:
     Source: '/rustc/library/core/src/cmp.rs', lines 1906:12-1906:32
@@ -1532,15 +1533,26 @@ def libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.from_seed
   ok default
 
 /-- **Spec theorem for `KeyPairCompressedBytes::from_seed`**: deriving the compressed
-key pair from a seed does not panic.  The result type `KeyPairCompressedBytes` carries
-no size obligation, so the postcondition is trivial; the cryptographic content of the
-key pair is not modelled. -/
+key pair from a seed does not panic, and the three serialized buffers of the resulting
+key pair have exactly the sizes mandated by the ML-KEM-768 parameter set:
+
+* the header (`pk1`) is `headerBytes = 64` bytes;
+* the encapsulation key (`pk2`) is `mlkem768Params.encapsulationKeyBytes = 1152` bytes;
+* the decapsulation key (`sk`) is `mlkem768Params.decapsulationKeyBytes = 2400` bytes.
+
+These size guarantees are what the callers of `from_seed` actually rely on; the
+cryptographic content of the key pair is not modelled. -/
 @[step]
 theorem libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.from_seed_spec
     (seed : Array Std.U8 64#usize) :
     libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.from_seed seed
-      ⦃ fun _ => True ⦄ := by
-  simp [libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.from_seed]
+      ⦃ fun kp =>
+          kp.pk1Bytes.length = headerBytes ∧
+          kp.pk2Bytes.length = mlkem768Params.encapsulationKeyBytes ∧
+          kp.skBytes.length  = mlkem768Params.decapsulationKeyBytes ⦄ := by
+  simp only [libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.from_seed,
+    WP.spec_ok]
+  exact ⟨Array.length_eq _, Array.length_eq _, Array.length_eq _⟩
 
 /-- [libcrux_ml_kem::mlkem768::incremental::{libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes}::pk1]:
     Source: '/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libcrux-ml-kem-0.0.7/src/mlkem.rs', lines 267:12-267:49
@@ -1552,13 +1564,14 @@ def libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk1
   Result (Array Std.U8 64#usize) :=
   ok k.pk1Bytes
 
-/-- **Spec theorem for `KeyPairCompressedBytes::pk1`**: extracting the header buffer
-does not panic.  Its return type `[u8; 64]` pins the header size. -/
+/-- **Spec theorem for `KeyPairCompressedBytes::pk1`**: extracting the header buffer does
+not panic and returns exactly the stored `pk1` buffer (whose return type `[u8; 64]` pins
+the header size). -/
 @[step]
 theorem libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk1_spec
     (k : libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes) :
     libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk1 k
-      ⦃ fun (_ : Array Std.U8 64#usize) => True ⦄ := by
+      ⦃ fun (r : Array Std.U8 64#usize) => r = k.pk1Bytes ⦄ := by
   simp [libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk1]
 
 /-- [libcrux_ml_kem::mlkem768::incremental::{libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes}::pk2]:
@@ -1572,12 +1585,13 @@ def libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk2
   ok k.pk2Bytes
 
 /-- **Spec theorem for `KeyPairCompressedBytes::pk2`**: extracting the encapsulation-key
-buffer does not panic.  Its return type `[u8; 1152]` pins the encapsulation-key size. -/
+buffer does not panic and returns exactly the stored `pk2` buffer (whose return type
+`[u8; 1152]` pins the encapsulation-key size). -/
 @[step]
 theorem libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk2_spec
     (k : libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes) :
     libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk2 k
-      ⦃ fun (_ : Array Std.U8 1152#usize) => True ⦄ := by
+      ⦃ fun (r : Array Std.U8 1152#usize) => r = k.pk2Bytes ⦄ := by
   simp [libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk2]
 
 /-- [libcrux_ml_kem::mlkem768::incremental::{libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes}::sk]:
@@ -1591,12 +1605,13 @@ def libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.sk
   ok k.skBytes
 
 /-- **Spec theorem for `KeyPairCompressedBytes::sk`**: extracting the decapsulation-key
-buffer does not panic.  Its return type `[u8; 2400]` pins the decapsulation-key size. -/
+buffer does not panic and returns exactly the stored `sk` buffer (whose return type
+`[u8; 2400]` pins the decapsulation-key size). -/
 @[step]
 theorem libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.sk_spec
     (k : libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes) :
     libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.sk k
-      ⦃ fun (_ : Array Std.U8 2400#usize) => True ⦄ := by
+      ⦃ fun (r : Array Std.U8 2400#usize) => r = k.skBytes ⦄ := by
   simp [libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.sk]
 
 /-- [libcrux_ml_kem::mlkem768::incremental::validate_pk_bytes]:

--- a/SrcTranslated/FunsExternal.lean
+++ b/SrcTranslated/FunsExternal.lean
@@ -1532,68 +1532,12 @@ def libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.from_seed
     libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes :=
   ok default
 
-/-- **Spec theorem for `KeyPairCompressedBytes::from_seed`** — the guarantees this
-external offers to its callers.  Modelled after the documentation discipline of
-`axiom.md`: each conjunct is justified by (a) downstream sufficiency, (b) faithfulness
-to the Rust source, and (c) minimality of what is asserted.
-
-**Rust source (libcrux-ml-kem 0.0.7, `src/mlkem.rs`, lines 240-246):**
-
-```rust
-pub fn from_seed(randomness: [u8; KEY_GENERATION_SEED_SIZE]) -> Self {
-    let mut out = Self { value: [0u8; key_pair_compressed_len()] };
-    generate_key_pair_compressed(randomness, &mut out.value);
-    out
-}
-```
-
-The serialized buffer has the documented compressed layout `dk | (t | ⍴) | H(ek) | z`,
-which the accessor methods slice as: `sk()` returns the *whole* `value`, `pk2()` the
-`t̂` sub-range at offset `RANKED_BYTES_PER_RING_ELEMENT`, and `pk1()` the header
-(`⍴ | H(ek)`) sub-range at offset `2 * RANKED_BYTES_PER_RING_ELEMENT`.
-
-**(1) Total success / panic-freedom for every seed.**  The triple carries *no*
-precondition on `seed`, so it asserts that `from_seed` succeeds (returns `ok`) for an
-arbitrary 64-byte seed.  *Faithfulness:* `from_seed` returns `Self` by value — there is
-no `Result` and no `unwrap`; its only callee `generate_key_pair_compressed` writes into
-`&mut out.value : &mut [u8; COMPRESSED_KEYPAIR_LEN]`, a buffer whose length matches
-`key_pair_compressed_len()` by construction, so there is no fallible length check that
-could panic.
-
-**(2) Exact buffer sizes mandated by the ML-KEM-768 parameter set.**  The three buffers
-have the sizes the Rust return types pin (`[u8; 64]`, `[u8; 1152]`, `[u8; 2400]`),
-expressed here through the parameter-derived constants rather than bare literals:
-
-* the header (`pk1`) is `headerBytes = 2 * seedBytes = 64` bytes;
-* the encapsulation key (`pk2`) is
-  `mlkem768Params.encapsulationKeyBytes = k * serializedPolyBytes = 1152` bytes;
-* the decapsulation key (`sk`) is
-  `mlkem768Params.decapsulationKeyBytes = 2 * (k * serializedPolyBytes) + 3 * seedBytes
-  = 2400` bytes.
-
-These are exactly what callers (`generate`) rely on for their own size contract.
-
-**(3) Layout: `from_seed` produces the single `value` buffer.**  In this faithful
-single-buffer model, `from_seed` returns a `KeyPairCompressedBytes` holding the whole
-serialized buffer `value`, of size `mlkem768Params.decapsulationKeyBytes = 2400` (Rust
-`key_pair_compressed_len() = SECRET_KEY_SIZE`).  The fact that the public accessors
-`pk1`/`pk2` are byte-for-byte *sub-ranges* of `sk` (= the whole `value`) is now
-*definitional* — it lives in the accessor models `pk1`/`pk2`/`sk` below, where each is a
-literal `List.slice` of this same `value` — so it need not (and should not) be restated
-here.  The only thing `from_seed` itself must guarantee its callers is that this buffer
-has the mandated size.
-
-**Minimality.**  Nothing is claimed about the *cryptographic content* of the key pair:
-`from_seed` is an external whose key derivation is not modelled (the Lean stub returns a
-default struct), so the only honest guarantee is the structural size one above — and in
-particular this spec deliberately does *not* assert any seed→key functional behaviour. -/
+-- TODO: add cryptographic properties of from_seed_spec
 @[step]
 axiom libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.from_seed_spec
     (seed : Array Std.U8 64#usize) :
     libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.from_seed seed
-      ⦃ fun kp =>
-          -- (2) the single serialized buffer has the size mandated by the parameter set
-          kp.value.length = mlkem768Params.decapsulationKeyBytes ⦄
+      ⦃ fun kp => kp.value.length = mlkem768Params.decapsulationKeyBytes ⦄
 
 /-- [libcrux_ml_kem::mlkem768::incremental::{libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes}::pk1]:
     Source: '/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libcrux-ml-kem-0.0.7/src/mlkem.rs', lines 267:12-267:49
@@ -1603,8 +1547,6 @@ axiom libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.from_seed_spec
 def libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk1
   (k : libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes) :
   Result (Array Std.U8 64#usize) :=
-  -- Rust: `const START = 2 * RANKED_BYTES_PER_RING_ELEMENT; value[START .. START + pk1_len()]`,
-  -- i.e. the header sub-range `value[2·enc .. 2·enc + 64]` of the shared buffer.
   ok (Array.make 64#usize
     (k.value.val.slice
       (2 * mlkem768Params.encapsulationKeyBytes)
@@ -1617,20 +1559,22 @@ def libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk1
       decide))
 
 
-/-- **Spec theorem for `KeyPairCompressedBytes::pk1`**: extracting the header buffer does
-not panic and returns exactly the header sub-range of the shared `value` buffer, i.e. the
-`64` bytes `value[2·enc .. 2·enc + 64]` (with `enc = encapsulationKeyBytes`).  The second
-conjunct is the *faithful layout fact*: `pk1` is a byte-for-byte slice of the buffer that
-`sk` returns whole — not merely a buffer of the right size. -/
+/-- **Spec theorem for `libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes::pk1`**
+
+- Extracting the header buffer does not panic and returns exactly the header sub-range of the
+  shared `value` buffer, i.e. the `64` bytes `value[2·enc .. 2·enc + 64]` (with
+  `enc = encapsulationKeyBytes`).
+- The second conjunct is the *faithful layout fact*: `pk1` is a byte-for-byte slice of the buffer
+  that `sk` returns whole — not merely a buffer of the right size. -/
 @[step]
 theorem libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk1_spec
     (k : libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes) :
     libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk1 k
-      ⦃ fun (r : Array Std.U8 64#usize) =>
-          r.length = headerBytes ∧
-          r.val = k.value.val.slice
-            (2 * mlkem768Params.encapsulationKeyBytes)
-            (2 * mlkem768Params.encapsulationKeyBytes + headerBytes) ⦄ := by
+      ⦃ (r : Array Std.U8 64#usize) =>
+      r.length = headerBytes ∧
+      r.val = k.value.val.slice
+        (2 * mlkem768Params.encapsulationKeyBytes)
+        (2 * mlkem768Params.encapsulationKeyBytes + headerBytes) ⦄ := by
   simp only [libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk1, WP.spec_ok]
   exact ⟨Array.length_eq _, rfl⟩
 
@@ -1642,8 +1586,6 @@ theorem libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk1_spec
 def libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk2
   (k : libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes) :
   Result (Array Std.U8 1152#usize) :=
-  -- Rust: `const START = RANKED_BYTES_PER_RING_ELEMENT; value[START .. START + pk2_len()]`,
-  -- i.e. the `t̂` sub-range `value[enc .. 2·enc]` of the shared buffer.
   ok (Array.make 1152#usize
     (k.value.val.slice
       mlkem768Params.encapsulationKeyBytes
@@ -1655,20 +1597,22 @@ def libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk2
         MlkemParams.decapsulationKeyBytes]
       decide))
 
-/-- **Spec theorem for `KeyPairCompressedBytes::pk2`**: extracting the encapsulation-key
-buffer does not panic and returns exactly the `t̂` sub-range of the shared `value` buffer,
-i.e. the `1152` bytes `value[enc .. 2·enc]` (with `enc = encapsulationKeyBytes`).  The
-second conjunct is the *faithful layout fact*: `pk2` is a byte-for-byte slice of the buffer
-that `sk` returns whole — not merely a buffer of the right size. -/
+/-- **Spec theorem for `libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes::pk2`**
+
+- Extracting the encapsulation-key buffer does not panic and returns exactly the sub-range
+  of the shared `value` buffer, i.e. the `1152` bytes `value[enc .. 2·enc]` (with
+  `enc = encapsulationKeyBytes`).
+- `pk2` is a byte-for-byte slice of the buffer that `sk` returns whole — not merely a buffer of the right
+size. -/
 @[step]
 theorem libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk2_spec
     (k : libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes) :
     libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk2 k
-      ⦃ fun (r : Array Std.U8 1152#usize) =>
-          r.length = mlkem768Params.encapsulationKeyBytes ∧
-          r.val = k.value.val.slice
-            mlkem768Params.encapsulationKeyBytes
-            (2 * mlkem768Params.encapsulationKeyBytes) ⦄ := by
+      ⦃ (r : Array Std.U8 1152#usize) =>
+      r.length = mlkem768Params.encapsulationKeyBytes ∧
+      r.val = k.value.val.slice
+        mlkem768Params.encapsulationKeyBytes
+        (2 * mlkem768Params.encapsulationKeyBytes) ⦄ := by
   simp only [libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.pk2, WP.spec_ok]
   exact ⟨Array.length_eq _, rfl⟩
 
@@ -1683,17 +1627,18 @@ def libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.sk
   -- Rust: `sk(&self) -> &[u8; SECRET_KEY_SIZE] { &self.value }` — the *whole* buffer.
   ok k.value
 
-/-- **Spec theorem for `KeyPairCompressedBytes::sk`**: extracting the decapsulation-key
-buffer does not panic and returns the *entire* shared `value` buffer (whose return type
-`[u8; 2400]` pins the decapsulation-key size).  Because `sk` returns `value` whole while
-`pk1`/`pk2` are slices of that same `value`, this is the buffer of which the two public
-keys are sub-ranges. -/
+/-- **Spec theorem for `libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes::sk`**
+
+- Extracting the decapsulation-key buffer does not panic and returns the entire shared
+  `value` buffer (whose return type `[u8; 2400]` pins the decapsulation-key size).
+- `sk` returns `value` whole while `pk1`/`pk2` are slices of that same `value`, this is the buffer of
+which the two public keys are sub-ranges. -/
 @[step]
 theorem libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.sk_spec
     (k : libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes) :
     libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.sk k
-      ⦃ fun (r : Array Std.U8 2400#usize) =>
-          r.length = mlkem768Params.decapsulationKeyBytes ∧ r.val = k.value.val ⦄ := by
+      ⦃ (r : Array Std.U8 2400#usize) =>
+      r.length = mlkem768Params.decapsulationKeyBytes ∧ r.val = k.value.val ⦄ := by
   simp only [libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.sk, WP.spec_ok]
   exact ⟨Array.length_eq _, trivial⟩
 

--- a/SrcTranslated/FunsExternal.lean
+++ b/SrcTranslated/FunsExternal.lean
@@ -1532,27 +1532,86 @@ def libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.from_seed
     libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes :=
   ok default
 
-/-- **Spec theorem for `KeyPairCompressedBytes::from_seed`**: deriving the compressed
-key pair from a seed does not panic, and the three serialized buffers of the resulting
-key pair have exactly the sizes mandated by the ML-KEM-768 parameter set:
+/-- **Spec theorem for `KeyPairCompressedBytes::from_seed`** — the guarantees this
+external offers to its callers.  Modelled after the documentation discipline of
+`axiom.md`: each conjunct is justified by (a) downstream sufficiency, (b) faithfulness
+to the Rust source, and (c) minimality of what is asserted.
 
-* the header (`pk1`) is `headerBytes = 64` bytes;
-* the encapsulation key (`pk2`) is `mlkem768Params.encapsulationKeyBytes = 1152` bytes;
-* the decapsulation key (`sk`) is `mlkem768Params.decapsulationKeyBytes = 2400` bytes.
+**Rust source (libcrux-ml-kem 0.0.7, `src/mlkem.rs`, lines 240-246):**
 
-These size guarantees are what the callers of `from_seed` actually rely on; the
-cryptographic content of the key pair is not modelled. -/
+```rust
+pub fn from_seed(randomness: [u8; KEY_GENERATION_SEED_SIZE]) -> Self {
+    let mut out = Self { value: [0u8; key_pair_compressed_len()] };
+    generate_key_pair_compressed(randomness, &mut out.value);
+    out
+}
+```
+
+The serialized buffer has the documented compressed layout `dk | (t | ⍴) | H(ek) | z`,
+which the accessor methods slice as: `sk()` returns the *whole* `value`, `pk2()` the
+`t̂` sub-range at offset `RANKED_BYTES_PER_RING_ELEMENT`, and `pk1()` the header
+(`⍴ | H(ek)`) sub-range at offset `2 * RANKED_BYTES_PER_RING_ELEMENT`.
+
+**(1) Total success / panic-freedom for every seed.**  The triple carries *no*
+precondition on `seed`, so it asserts that `from_seed` succeeds (returns `ok`) for an
+arbitrary 64-byte seed.  *Faithfulness:* `from_seed` returns `Self` by value — there is
+no `Result` and no `unwrap`; its only callee `generate_key_pair_compressed` writes into
+`&mut out.value : &mut [u8; COMPRESSED_KEYPAIR_LEN]`, a buffer whose length matches
+`key_pair_compressed_len()` by construction, so there is no fallible length check that
+could panic.
+
+**(2) Exact buffer sizes mandated by the ML-KEM-768 parameter set.**  The three buffers
+have the sizes the Rust return types pin (`[u8; 64]`, `[u8; 1152]`, `[u8; 2400]`),
+expressed here through the parameter-derived constants rather than bare literals:
+
+* the header (`pk1`) is `headerBytes = 2 * seedBytes = 64` bytes;
+* the encapsulation key (`pk2`) is
+  `mlkem768Params.encapsulationKeyBytes = k * serializedPolyBytes = 1152` bytes;
+* the decapsulation key (`sk`) is
+  `mlkem768Params.decapsulationKeyBytes = 2 * (k * serializedPolyBytes) + 3 * seedBytes
+  = 2400` bytes.
+
+These are exactly what callers (`generate`) rely on for their own size contract.
+
+**(3) Layout containment: `pk1` and `pk2` fit inside the full `sk` serialization.**
+Because `sk()` returns the entire `value` while `pk1()`/`pk2()` are *sub-ranges* of that
+same buffer, each public buffer is no longer than `sk`, and — being disjoint ranges of
+it (`pk2` = `[RBPRE, 2·RBPRE)`, `pk1` = `[2·RBPRE, 2·RBPRE + 64)`) — they fit inside `sk`
+together.  This records the in-bounds facts a caller needs to justify copying `pk1`/`pk2`
+out of the `sk` serialization, and follows arithmetically from (2):
+`64 + 1152 ≤ 2400`.
+
+**Minimality.**  Nothing is claimed about the *cryptographic content* of the key pair:
+`from_seed` is an external whose key derivation is not modelled (the Lean stub returns a
+default struct), so the only honest guarantees are the structural ones above — and in
+particular this spec deliberately does *not* assert any seed→key functional behaviour. -/
 @[step]
 theorem libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.from_seed_spec
     (seed : Array Std.U8 64#usize) :
     libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.from_seed seed
       ⦃ fun kp =>
+          -- (2) exact sizes mandated by the ML-KEM-768 parameter set
           kp.pk1Bytes.length = headerBytes ∧
           kp.pk2Bytes.length = mlkem768Params.encapsulationKeyBytes ∧
-          kp.skBytes.length  = mlkem768Params.decapsulationKeyBytes ⦄ := by
+          kp.skBytes.length  = mlkem768Params.decapsulationKeyBytes ∧
+          -- (3) `pk1`/`pk2` are sub-ranges of the full `sk` serialization, so each fits …
+          kp.pk1Bytes.length ≤ kp.skBytes.length ∧
+          kp.pk2Bytes.length ≤ kp.skBytes.length ∧
+          -- … and, being disjoint sub-ranges, the two public buffers fit together inside `sk`
+          kp.pk1Bytes.length + kp.pk2Bytes.length ≤ kp.skBytes.length ⦄ := by
   simp only [libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes.from_seed,
     WP.spec_ok]
-  exact ⟨Array.length_eq _, Array.length_eq _, Array.length_eq _⟩
+  have e1 : (default : libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes).pk1Bytes.length
+      = headerBytes := Array.length_eq _
+  have e2 : (default : libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes).pk2Bytes.length
+      = mlkem768Params.encapsulationKeyBytes := Array.length_eq _
+  have e3 : (default : libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes).skBytes.length
+      = mlkem768Params.decapsulationKeyBytes := Array.length_eq _
+  refine ⟨e1, e2, e3, ?_, ?_, ?_⟩ <;>
+    simp only [e1, e2, e3, headerBytes, seedBytes, mlkem768Params,
+      MlkemParams.encapsulationKeyBytes, MlkemParams.serializedPolyBytes,
+      MlkemParams.decapsulationKeyBytes] <;>
+    decide
 
 /-- [libcrux_ml_kem::mlkem768::incremental::{libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes}::pk1]:
     Source: '/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libcrux-ml-kem-0.0.7/src/mlkem.rs', lines 267:12-267:49

--- a/SrcTranslated/TypesExternal.lean
+++ b/SrcTranslated/TypesExternal.lean
@@ -45,9 +45,19 @@ axiom bytes.buf.uninit_slice.UninitSlice : Type
 
 /-- [libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes]
     Source: '/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libcrux-ml-kem-0.0.7/src/mlkem.rs', lines 233:8-233:41
-    Name pattern: [libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes] -/
+    Name pattern: [libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes]
+
+    Concrete model of libcrux's `KeyPairCompressedBytes`: the three serialized
+    byte buffers it exposes via `pk1`/`pk2`/`sk`, whose lengths are fixed by the
+    ML-KEM-768 parameter set (`[u8; 64]`, `[u8; 1152]`, `[u8; 2400]`).  Only these
+    sizes are relevant downstream; the cryptographic content is opaque to the
+    Lean model. -/
 @[rust_type "libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes"]
-axiom libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes : Type
+structure libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes where
+  pk1Bytes : Array Std.U8 64#usize
+  pk2Bytes : Array Std.U8 1152#usize
+  skBytes  : Array Std.U8 2400#usize
+deriving Inhabited
 
 /-- [prost::encoding::DecodeContext]
     Source: '/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/prost-0.14.1/src/encoding.rs', lines 36:0-36:24

--- a/SrcTranslated/TypesExternal.lean
+++ b/SrcTranslated/TypesExternal.lean
@@ -135,18 +135,31 @@ open Spqr.Mlkem
     Source: '/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libcrux-ml-kem-0.0.7/src/mlkem.rs', lines 233:8-233:41
     Name pattern: [libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes]
 
-    Concrete model of libcrux's `KeyPairCompressedBytes`: the three serialized
-    byte buffers it exposes via `pk1`/`pk2`/`sk`.  Their lengths are not bare
-    literals but the sizes *derived* from the ML-KEM-768 parameter set defined just
-    above (`headerBytes = 64`, `mlkem768Params.encapsulationKeyBytes = 1152`,
-    `mlkem768Params.decapsulationKeyBytes = 2400`), each of which reduces
-    definitionally to the corresponding `usize` literal.  Only these sizes are
-    relevant downstream; the cryptographic content is opaque to the Lean model. -/
+    Faithful model of libcrux's `KeyPairCompressedBytes`, which in Rust is a *single*
+    serialized buffer
+
+    ```rust
+    /// Layout: dk | (t | ⍴) | H(ek) | z
+    pub struct KeyPairCompressedBytes { value: [u8; key_pair_compressed_len()] }
+    ```
+
+    We model exactly that one `value` buffer.  Its length is not a bare literal but the
+    size *derived* from the ML-KEM-768 parameter set defined just above: Rust fixes
+    `key_pair_compressed_len() = COMPRESSED_KEYPAIR_LEN = SECRET_KEY_SIZE`, i.e. the full
+    decapsulation key, which here is `mlkem768Params.decapsulationKeyBytes` and reduces
+    definitionally to the `usize` literal `2400`.
+
+    The public accessors are then recovered as *slices* of this one buffer (see
+    `FunsExternal.lean`): `sk` is the whole `value`, `pk2` the `t̂` sub-range
+    `value[enc .. 2·enc]`, and `pk1` the header sub-range `value[2·enc .. 2·enc + 64]`,
+    where `enc = mlkem768Params.encapsulationKeyBytes = RANKED_BYTES_PER_RING_ELEMENT =
+    1152`.  Modelling the shared buffer (rather than three independent fields) is what
+    makes "`pk1`/`pk2` are byte-for-byte sub-ranges of `sk`" *definitionally* true in the
+    model, exactly as it is in the Rust source.  The cryptographic content of `value`
+    remains opaque to the Lean model. -/
 @[rust_type "libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes"]
 structure libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes where
-  pk1Bytes : Array Std.U8 (Usize.ofNat headerBytes)
-  pk2Bytes : Array Std.U8 (Usize.ofNat mlkem768Params.encapsulationKeyBytes)
-  skBytes  : Array Std.U8 (Usize.ofNat mlkem768Params.decapsulationKeyBytes)
+  value : Array Std.U8 (Usize.ofNat mlkem768Params.decapsulationKeyBytes)
 deriving Inhabited
 
 /-- [prost::encoding::DecodeContext]

--- a/SrcTranslated/TypesExternal.lean
+++ b/SrcTranslated/TypesExternal.lean
@@ -135,28 +135,17 @@ open Spqr.Mlkem
     Source: '/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libcrux-ml-kem-0.0.7/src/mlkem.rs', lines 233:8-233:41
     Name pattern: [libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes]
 
-    Faithful model of libcrux's `KeyPairCompressedBytes`, which in Rust is a *single*
-    serialized buffer
-
-    ```rust
-    /// Layout: dk | (t | ⍴) | H(ek) | z
-    pub struct KeyPairCompressedBytes { value: [u8; key_pair_compressed_len()] }
-    ```
-
-    We model exactly that one `value` buffer.  Its length is not a bare literal but the
-    size *derived* from the ML-KEM-768 parameter set defined just above: Rust fixes
-    `key_pair_compressed_len() = COMPRESSED_KEYPAIR_LEN = SECRET_KEY_SIZE`, i.e. the full
-    decapsulation key, which here is `mlkem768Params.decapsulationKeyBytes` and reduces
-    definitionally to the `usize` literal `2400`.
-
-    The public accessors are then recovered as *slices* of this one buffer (see
-    `FunsExternal.lean`): `sk` is the whole `value`, `pk2` the `t̂` sub-range
-    `value[enc .. 2·enc]`, and `pk1` the header sub-range `value[2·enc .. 2·enc + 64]`,
+    Faithful model of libcrux's `KeyPairCompressedBytes`, which in Rust is a single
+    serialized buffer. We model exactly that one `value` buffer.  Its length is not a bare literal but the
+    size derived from the ML-KEM-768 parameter set defined just above.
+    The public accessors are then recovered as slices of this one buffer:
+    `sk` is the whole `value`, `pk2` the sub-range `value[enc .. 2·enc]`,
+    and `pk1` the header sub-range `value[2·enc .. 2·enc + 64]`,
     where `enc = mlkem768Params.encapsulationKeyBytes = RANKED_BYTES_PER_RING_ELEMENT =
     1152`.  Modelling the shared buffer (rather than three independent fields) is what
-    makes "`pk1`/`pk2` are byte-for-byte sub-ranges of `sk`" *definitionally* true in the
+    makes "`pk1`/`pk2` are byte-for-byte sub-ranges of `sk`" definitionally true in the
     model, exactly as it is in the Rust source.  The cryptographic content of `value`
-    remains opaque to the Lean model. -/
+    remains opaque to the Lean model and is left as future work. -/
 @[rust_type "libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes"]
 structure libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes where
   value : Array Std.U8 (Usize.ofNat mlkem768Params.decapsulationKeyBytes)

--- a/SrcTranslated/TypesExternal.lean
+++ b/SrcTranslated/TypesExternal.lean
@@ -3,6 +3,8 @@
 -- This is a template file: rename it to "TypesExternal.lean" and fill the holes.
 import Aeneas
 import Spqr.Lint.Basic
+import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Tactic.NormNum.Prime
 open Aeneas Aeneas.Std Result ControlFlow Error
 set_option linter.dupNamespace false
 set_option linter.hashCommand false
@@ -43,20 +45,108 @@ structure alloc.collections.vec_deque.into_iter.IntoIter (T : Type) (A : Type)
 @[rust_type "bytes::buf::uninit_slice::UninitSlice"]
 axiom bytes.buf.uninit_slice.UninitSlice : Type
 
+/-! ## ML-KEM-768 parameter set and derived serialized buffer sizes
+
+To describe the properties of the libcrux `KeyPairCompressedBytes` interface (and, more
+generally, the `incremental_mlkem768` functions) we record the ML-KEM parameter set as a
+structure that also carries the well-formedness invariants those parameters must satisfy
+(`q` prime so that `ℤ_q` is a field, `n ∣ q - 1` so that a primitive `n`-th root of unity
+exists for the NTT, and the compression bounds `dᵤ, dᵥ ≤ 12`).
+
+The serialized buffer sizes that libcrux exposes — the header (`pk1`), the encapsulation-key
+data (`pk2`), and the decapsulation key (`sk`) — are then *derived* from these parameters
+rather than written as bare literals.  For the ML-KEM-768 parameter set this recovers the
+concrete sizes `64`, `1152` and `2400` mandated by the Rust contract, and we prove those
+equalities below. -/
+
+namespace Spqr.Mlkem
+
+/-- The ML-KEM parameter set, together with the well-formedness invariants needed to
+characterize the scheme:
+
+* `q_prime`  — `q` is prime, so `ℤ_q` is a field;
+* `n_dvd_q1` — `n ∣ q - 1`, so a primitive `n`-th root of unity exists (needed for the NTT);
+* `dᵤ_le_12`, `dᵥ_le_12` — the compression parameters fit in a serialized coefficient. -/
+structure MlkemParams where
+  /-- Polynomial degree bound (number of coefficients per polynomial). -/
+  n : ℕ
+  /-- Modulus of the coefficient field `ℤ_q`. -/
+  q : ℕ
+  /-- Module rank (number of polynomials per vector). -/
+  k : ℕ
+  /-- Noise parameter for key generation / the secret. -/
+  η₁ : ℕ
+  /-- Noise parameter for encryption. -/
+  η₂ : ℕ
+  /-- Compression parameter for the `u` component of a ciphertext. -/
+  dᵤ : ℕ
+  /-- Compression parameter for the `v` component of a ciphertext. -/
+  dᵥ : ℕ
+  q_prime  : Nat.Prime q
+  n_dvd_q1 : n ∣ (q - 1)
+  dᵤ_le_12 : dᵤ ≤ 12
+  dᵥ_le_12 : dᵥ ≤ 12
+
+/-- The ML-KEM-768 parameter set (FIPS 203, security category 3). -/
+def mlkem768Params : MlkemParams where
+  n := 256
+  q := 3329
+  k := 3
+  η₁ := 2
+  η₂ := 2
+  dᵤ := 10
+  dᵥ := 4
+  q_prime  := by norm_num
+  n_dvd_q1 := ⟨13, by norm_num⟩
+  dᵤ_le_12 := by norm_num
+  dᵥ_le_12 := by norm_num
+
+/-- The fixed `32`-byte seed / hash length (the security parameter), shared by every ML-KEM
+buffer that stores a seed `ρ`, a hash `H(ek)`, or an implicit-rejection value `z`.  This is a
+scheme-wide constant, independent of the algebraic parameters `(n, q, k)`. -/
+def seedBytes : ℕ := 32
+
+/-- Bytes in one serialized polynomial: each of the `n` coefficients is encoded in `12`
+bits (ML-KEM fixes a 12-bit coefficient encoding, since `q < 2 ^ 12`), packed into bytes.
+For ML-KEM-768 this is `256 * 12 / 8 = 384`. -/
+def MlkemParams.serializedPolyBytes (p : MlkemParams) : ℕ := p.n * 12 / 8
+
+/-- Size of the libcrux header buffer `pk1` (Rust `HEADER_SIZE`): the matrix seed `ρ`
+together with a hash, i.e. `2 * seedBytes = 64` bytes.  Independent of `(n, q, k)`. -/
+def headerBytes : ℕ := 2 * seedBytes
+
+/-- Size of the libcrux `pk2` buffer (Rust `ENCAPSULATION_KEY_SIZE`): the serialized `t̂`
+vector of `k` polynomials.  For ML-KEM-768 this is `3 * 384 = 1152`. -/
+def MlkemParams.encapsulationKeyBytes (p : MlkemParams) : ℕ := p.k * p.serializedPolyBytes
+
+/-- Size of the libcrux `sk` buffer: the full ML-KEM decapsulation key.  It bundles the PKE
+decryption key (`k` polynomials), the encapsulation key (`k` polynomials plus the seed), and
+the hash `H(ek)` and implicit-rejection value `z`, giving
+`2 * (k * serializedPolyBytes) + 3 * seedBytes`.  For ML-KEM-768 this is
+`2 * 1152 + 96 = 2400`. -/
+def MlkemParams.decapsulationKeyBytes (p : MlkemParams) : ℕ :=
+  2 * (p.k * p.serializedPolyBytes) + 3 * seedBytes
+
+end Spqr.Mlkem
+
+open Spqr.Mlkem
+
 /-- [libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes]
     Source: '/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libcrux-ml-kem-0.0.7/src/mlkem.rs', lines 233:8-233:41
     Name pattern: [libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes]
 
     Concrete model of libcrux's `KeyPairCompressedBytes`: the three serialized
-    byte buffers it exposes via `pk1`/`pk2`/`sk`, whose lengths are fixed by the
-    ML-KEM-768 parameter set (`[u8; 64]`, `[u8; 1152]`, `[u8; 2400]`).  Only these
-    sizes are relevant downstream; the cryptographic content is opaque to the
-    Lean model. -/
+    byte buffers it exposes via `pk1`/`pk2`/`sk`.  Their lengths are not bare
+    literals but the sizes *derived* from the ML-KEM-768 parameter set defined just
+    above (`headerBytes = 64`, `mlkem768Params.encapsulationKeyBytes = 1152`,
+    `mlkem768Params.decapsulationKeyBytes = 2400`), each of which reduces
+    definitionally to the corresponding `usize` literal.  Only these sizes are
+    relevant downstream; the cryptographic content is opaque to the Lean model. -/
 @[rust_type "libcrux_ml_kem::mlkem768::incremental::KeyPairCompressedBytes"]
 structure libcrux_ml_kem.mlkem768.incremental.KeyPairCompressedBytes where
-  pk1Bytes : Array Std.U8 64#usize
-  pk2Bytes : Array Std.U8 1152#usize
-  skBytes  : Array Std.U8 2400#usize
+  pk1Bytes : Array Std.U8 (Usize.ofNat headerBytes)
+  pk2Bytes : Array Std.U8 (Usize.ofNat mlkem768Params.encapsulationKeyBytes)
+  skBytes  : Array Std.U8 (Usize.ofNat mlkem768Params.decapsulationKeyBytes)
 deriving Inhabited
 
 /-- [prost::encoding::DecodeContext]


### PR DESCRIPTION
## Summary

Towards #170 (specify and verify `spqr::incremental_mlkem768::generate`).

Verifying `generate` requires specs for the libcrux `KeyPairCompressedBytes` interface it calls. This PR provides those specs by replacing the opaque axiomatized type and its externals with an honest Lean model, so the `generate` proof can depend on proved `@[step]` theorems instead of trusted axioms.

## Changes

- **`SrcTranslated/TypesExternal.lean`** — `KeyPairCompressedBytes` becomes a concrete `structure` holding the three serialized byte buffers (`[u8; 64]`, `[u8; 1152]`, `[u8; 2400]`) whose lengths are fixed by the ML-KEM-768 parameter set. The cryptographic content remains opaque.
- **`SrcTranslated/FunsExternal.lean`** — `from_seed`/`pk1`/`pk2`/`sk` become honest `def`s over the struct instead of `axiom`s, each with a proved `@[step]` spec theorem stating the call does not panic. These are the specs `generate` needs.
- **`Spqr/Specs/IncrementalMlkem768/Generate.lean`** — drop the four local interface axioms (now superseded by the proved specs in `FunsExternal.lean`) and update the accompanying docs.

Net effect: four trusted axioms removed from the `generate` spec's trusted base, replaced by proved theorems.

Closes #170