### PR TITLE
Move `add_assign_spec` for `Poly` out of the `test` namespace

### DIFF
--- a/Spqr/Specs/Encoding/Polynomial/Poly/AddAssign.lean
+++ b/Spqr/Specs/Encoding/Polynomial/Poly/AddAssign.lean
@@ -304,7 +304,7 @@ theorem loop_spec
 
 end spqr.encoding.polynomial.Poly.add_assign_loop
 
-namespace spqr.encoding.polynomial.Poly.test
+namespace spqr.encoding.polynomial.Poly
 
 /-- **Spec theorem for `encoding.polynomial.Poly.add_assign`**:
 
@@ -325,4 +325,4 @@ theorem add_assign_spec
   intro result h
   exact h
 
-end spqr.encoding.polynomial.Poly.test
+end spqr.encoding.polynomial.Poly


### PR DESCRIPTION
This PR renames `namespace spqr.encoding.polynomial.Poly.test` to `spqr.encoding.polynomial.Poly` in `Spqr/Specs/Encoding/Polynomial/Poly/AddAssign.lean`, so the spec theorem for `spqr::encoding::polynomial::Poly::add_assign` gets the full name `spqr.encoding.polynomial.Poly.add_assign_spec`. This matches the `<def-name>_spec` convention the verification tooling uses to link a def's primary spec (and the convention of the sibling spec files), so `Poly::add_assign` reports `verified` in extracts instead of `unverified`. The theorem itself is unchanged; nothing references the old namespace.

Closes #251

Made with [Cursor](https://cursor.com)