### PR TITLE
Specify and verify: `From<PolynomialError> for EncodingError::from` in `encoding.rs`

### DIFF
--- a/Spqr.lean
+++ b/Spqr.lean
@@ -42,6 +42,7 @@ import Spqr.Specs.Authenticator.Authenticator.MacCt
 import Spqr.Specs.Authenticator.Authenticator.MacHdr
 import Spqr.Specs.Authenticator.Serialize.Authenticator.FromPb
 import Spqr.Specs.Authenticator.Serialize.Authenticator.IntoPb
+import Spqr.Specs.Encoding.EncodingError.From
 import Spqr.Specs.Encoding.Gf.GF16.Add
 import Spqr.Specs.Encoding.Gf.GF16.AddAssign
 import Spqr.Specs.Encoding.Gf.GF16.ConstDiv

--- a/Spqr/Specs/Encoding/EncodingError/From.lean
+++ b/Spqr/Specs/Encoding/EncodingError/From.lean
@@ -1,0 +1,36 @@
+/-
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Liao Zhang
+-/
+import SrcTranslated.Funs
+
+/-! # Spec theorem for
+`spqr::encoding::{impl core::convert::From<spqr::encoding::polynomial::PolynomialError>`
+`for spqr::encoding::EncodingError}::from`
+
+This is the `From` conversion that lifts a `polynomial::PolynomialError` into the wider
+`EncodingError` type, letting the `?` operator turn a polynomial-layer error into an
+encoding-layer error automatically.
+
+**Source**: src/encoding.rs (lines 18:0-22:1)
+-/
+
+open Aeneas Aeneas.Std Result
+
+namespace spqr.encoding.EncodingError.Insts.CoreConvertFromPolynomialError
+
+/-- **Spec theorem for
+`impl From<PolynomialError> for EncodingError::from`**:
+
+• The call always succeeds (no panic).
+• The result is exactly the input error wrapped by the `EncodingError.PolynomialError`
+  constructor:
+    `from value = ok (EncodingError.PolynomialError value)`. -/
+@[step]
+theorem from_spec (value : encoding.polynomial.PolynomialError) :
+    «from» value ⦃ (result : encoding.EncodingError) =>
+      result = encoding.EncodingError.PolynomialError value ⦄ := by
+  simp [«from»]
+
+end spqr.encoding.EncodingError.Insts.CoreConvertFromPolynomialError


### PR DESCRIPTION
Closes #161.

Adds a Lean spec theorem for the `From` conversion that lifts a
`polynomial::PolynomialError` into the wider `EncodingError` type
(`src/encoding.rs`, lines 18–22) — the conversion the `?` operator uses to
turn a polynomial-layer error into an encoding-layer error.