### PR TITLE
Lean model for alloc::collections::vec_deque: VecDeque and its IntoIter (group B)

### DIFF
--- a/SrcTranslated/FunsExternal.lean
+++ b/SrcTranslated/FunsExternal.lean
@@ -3079,6 +3079,39 @@ axiom
   Clause1_IntoIter) :
   I → Result (core.result.Result V E)
 
+/-- [alloc::collections::vec_deque::into_iter::{core::iter::traits::iterator::Iterator<T> for alloc::collections::vec_deque::into_iter::IntoIter<T, A>}::next]:
+    Source: '/rustc/library/alloc/src/collections/vec_deque/into_iter.rs', lines 47:4-47:35
+    Name pattern: [alloc::collections::vec_deque::into_iter::{core::iter::traits::iterator::Iterator<alloc::collections::vec_deque::into_iter::IntoIter<@T, @A>, @T>}::next] -/
+@[rust_fun
+  "alloc::collections::vec_deque::into_iter::{core::iter::traits::iterator::Iterator<alloc::collections::vec_deque::into_iter::IntoIter<@T, @A>, @T>}::next"]
+def
+  alloc.collections.vec_deque.into_iter.IntoIter.Insts.CoreIterTraitsIteratorIterator.next
+  {T : Type} {A : Type}
+  (intoIter: alloc.collections.vec_deque.into_iter.IntoIter T A):
+    Result ((Option T) × (alloc.collections.vec_deque.into_iter.IntoIter T A)) :=
+        let deq: alloc.collections.vec_deque.VecDeque T A := intoIter.inner
+        let len := deq.length
+        -- strictly speaking, we don't need to ITE here.
+        -- If length = 0 then (in `else`) newInner = inner and get? returns none, but
+        -- this way short-circuits computation
+        if (deq.length == 0#usize) then ok (none, intoIter)
+        else
+          do
+            -- "`self[0]`, if it exists, is `buf[head]`. `head < buf.capacity()`, unless `buf.capacity() == 0` when `head == 0`."
+            -- [https://doc.rust-lang.org/src/alloc/collections/vec_deque/mod.rs.html#108]
+            -- Therefore, instead of modifying the buffer, the iteration over deq only needs
+            -- to cycle through the head index to yield all elements
+            let newhead ←
+              -- "if `len == 0`, the exact value of `head` is unimportant"  [https://doc.rust-lang.org/src/alloc/collections/vec_deque/mod.rs.html#112]
+              if len == 0#usize then ok deq.head
+              else (Usize.wrapping_add deq.head 1#usize) % len -- mod actually never fails, since len !=0
+            let newInner: alloc.collections.vec_deque.VecDeque T A:= {
+              buf := deq.buf,
+              head := newhead,
+              length := len
+            }
+            ok (deq.buf.get? deq.head, {inner:= newInner})
+
 /-- [alloc::collections::vec_deque::into_iter::{core::iter::traits::iterator::Iterator<T> for alloc::collections::vec_deque::into_iter::IntoIter<T, A>}::map]:
     Source: '/rustc/library/alloc/src/collections/vec_deque/into_iter.rs', lines 43:0-43:49
     Name pattern: [alloc::collections::vec_deque::into_iter::{core::iter::traits::iterator::Iterator<alloc::collections::vec_deque::into_iter::IntoIter<@T, @A>, @T>}::map] -/

--- a/SrcTranslated/FunsExternal.lean
+++ b/SrcTranslated/FunsExternal.lean
@@ -3079,53 +3079,18 @@ axiom
   Clause1_IntoIter) :
   I → Result (core.result.Result V E)
 
-/-- [alloc::collections::vec_deque::into_iter::{core::iter::traits::iterator::Iterator<T> for alloc::collections::vec_deque::into_iter::IntoIter<T, A>}::next]:
-    Source: '/rustc/library/alloc/src/collections/vec_deque/into_iter.rs', lines 47:4-47:35
-    Name pattern: [alloc::collections::vec_deque::into_iter::{core::iter::traits::iterator::Iterator<alloc::collections::vec_deque::into_iter::IntoIter<@T, @A>, @T>}::next] -/
-@[rust_fun
-  "alloc::collections::vec_deque::into_iter::{core::iter::traits::iterator::Iterator<alloc::collections::vec_deque::into_iter::IntoIter<@T, @A>, @T>}::next"]
-axiom
-  alloc.collections.vec_deque.into_iter.IntoIter.Insts.CoreIterTraitsIteratorIterator.next
-  {T : Type} {A : Type} :
-  alloc.collections.vec_deque.into_iter.IntoIter T A → Result ((Option T) ×
-    (alloc.collections.vec_deque.into_iter.IntoIter T A))
-
-/-- [alloc::collections::vec_deque::into_iter::{core::iter::traits::iterator::Iterator<T> for alloc::collections::vec_deque::into_iter::IntoIter<T, A>}::enumerate]:
-    Source: '/rustc/library/alloc/src/collections/vec_deque/into_iter.rs', lines 43:0-43:49
-    Name pattern: [alloc::collections::vec_deque::into_iter::{core::iter::traits::iterator::Iterator<alloc::collections::vec_deque::into_iter::IntoIter<@T, @A>, @T>}::enumerate] -/
-@[rust_fun
-  "alloc::collections::vec_deque::into_iter::{core::iter::traits::iterator::Iterator<alloc::collections::vec_deque::into_iter::IntoIter<@T, @A>, @T>}::enumerate"]
-axiom
-  alloc.collections.vec_deque.into_iter.IntoIter.Insts.CoreIterTraitsIteratorIterator.enumerate
-  {T : Type} {A : Type} :
-  alloc.collections.vec_deque.into_iter.IntoIter T A → Result
-    (core.iter.adapters.enumerate.Enumerate
-    (alloc.collections.vec_deque.into_iter.IntoIter T A))
-
 /-- [alloc::collections::vec_deque::into_iter::{core::iter::traits::iterator::Iterator<T> for alloc::collections::vec_deque::into_iter::IntoIter<T, A>}::map]:
     Source: '/rustc/library/alloc/src/collections/vec_deque/into_iter.rs', lines 43:0-43:49
     Name pattern: [alloc::collections::vec_deque::into_iter::{core::iter::traits::iterator::Iterator<alloc::collections::vec_deque::into_iter::IntoIter<@T, @A>, @T>}::map] -/
 @[rust_fun
   "alloc::collections::vec_deque::into_iter::{core::iter::traits::iterator::Iterator<alloc::collections::vec_deque::into_iter::IntoIter<@T, @A>, @T>}::map"]
-axiom
+def
   alloc.collections.vec_deque.into_iter.IntoIter.Insts.CoreIterTraitsIteratorIterator.map
-  {T : Type} {A : Type} {B : Type} {F : Type} (coreopsfunctionFnMutFTupleTBInst
-  : core.ops.function.FnMut F T B) :
-  alloc.collections.vec_deque.into_iter.IntoIter T A → F → Result
-    (core.iter.adapters.map.Map (alloc.collections.vec_deque.into_iter.IntoIter
-    T A) F)
-
-/-- [alloc::collections::vec_deque::into_iter::{core::iter::traits::iterator::Iterator<T> for alloc::collections::vec_deque::into_iter::IntoIter<T, A>}::step_by]:
-    Source: '/rustc/library/alloc/src/collections/vec_deque/into_iter.rs', lines 43:0-43:49
-    Name pattern: [alloc::collections::vec_deque::into_iter::{core::iter::traits::iterator::Iterator<alloc::collections::vec_deque::into_iter::IntoIter<@T, @A>, @T>}::step_by] -/
-@[rust_fun
-  "alloc::collections::vec_deque::into_iter::{core::iter::traits::iterator::Iterator<alloc::collections::vec_deque::into_iter::IntoIter<@T, @A>, @T>}::step_by"]
-axiom
-  alloc.collections.vec_deque.into_iter.IntoIter.Insts.CoreIterTraitsIteratorIterator.step_by
-  {T : Type} {A : Type} :
-  alloc.collections.vec_deque.into_iter.IntoIter T A → Std.Usize → Result
-    (core.iter.adapters.step_by.StepBy
-    (alloc.collections.vec_deque.into_iter.IntoIter T A))
+  {T : Type} {A : Type} {B : Type} {F : Type}
+  (coreopsfunctionFnMutFTupleTBInst: core.ops.function.FnMut F T B)
+  (intoIter: alloc.collections.vec_deque.into_iter.IntoIter T A)
+  (fn: F): Result (core.iter.adapters.map.Map (alloc.collections.vec_deque.into_iter.IntoIter T A) F) :=
+    ok {iter:= intoIter, f:= fn}
 
 /-- [alloc::collections::vec_deque::{core::iter::traits::collect::FromIterator<T> for alloc::collections::vec_deque::VecDeque<T, alloc::alloc::Global>}::from_iter]:
     Source: '/rustc/library/alloc/src/collections/vec_deque/mod.rs', lines 3641:4-3641:67


### PR DESCRIPTION
<!--
Please ensure that your submitted PR follows our style guide and contribution rules.

All source code modifications, or proof cheats (`sorry`) must be highlighted and justified.

To see how your PR impacts performance, comment `!radar` and modify accordingly.
-->

- `alloc.collections.vec_deque.into_iter.IntoIter.Insts.CoreIterTraitsIteratorIterator.next`, `.enumerate`, and `.step_by` are redundant
- Added def for `.map`

closes #232
