### PR TITLE
Specify and verify: `spqr::serialize::{impl core::convert::From<spqr::encoding::polynomial::PolynomialError> for spqr::serialize::Error}::from` in `serialize.rs`

### DIFF
--- a/Spqr.lean
+++ b/Spqr.lean
@@ -106,6 +106,7 @@ import Spqr.Specs.Encoding.Polynomial.Pt.Deserialize
 import Spqr.Specs.Encoding.Polynomial.Pt.Serialize
 import Spqr.Specs.IncrementalMlkem768.FlipEndianness
 import Spqr.Specs.IncrementalMlkem768.Generate
+import Spqr.Specs.Serialize.Error.From
 import Spqr.Specs.Util.Compare
 import Spqr.Specs.Util.Inz
 import Spqr.Specs.Util.IsNonZero

--- a/Spqr/Specs/Serialize/Error/From.lean
+++ b/Spqr/Specs/Serialize/Error/From.lean
@@ -1,0 +1,37 @@
+/-
+Copyright 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Liao Zhang
+-/
+import SrcTranslated.Funs
+
+/-! # Spec theorem for
+`spqr::serialize::{impl core::convert::From<spqr::encoding::polynomial::PolynomialError>`
+`for spqr::serialize::Error}::from`
+
+This is the `From` conversion that maps any `polynomial::PolynomialError` to the
+`serialize::Error::EncodingDecoding` variant, letting the `?` operator turn a
+polynomial-layer error into a serialization-layer error automatically. The input
+error is discarded: every polynomial error collapses to `EncodingDecoding`.
+
+**Source**: src/serialize.rs (lines 14:0-18:1)
+-/
+
+open Aeneas Aeneas.Std Result
+
+namespace spqr.serialize.Error.Insts.CoreConvertFromPolynomialError
+
+/-- **Spec theorem for
+`impl From<PolynomialError> for serialize::Error::from`**:
+
+• The call always succeeds (no panic).
+• The result is the constant `serialize.Error.EncodingDecoding`, regardless of the
+  input error:
+    `from _e = ok serialize.Error.EncodingDecoding`. -/
+@[step]
+theorem from_spec (_e : encoding.polynomial.PolynomialError) :
+    «from» _e ⦃ (result : serialize.Error) =>
+      result = serialize.Error.EncodingDecoding ⦄ := by
+  simp [«from»]
+
+end spqr.serialize.Error.Insts.CoreConvertFromPolynomialError


### PR DESCRIPTION
Closes #291 (part of #290).

Adds `Spqr/Specs/Serialize/Error/From.lean` with the `@[step]` spec theorem `from_spec` for the extracted function `serialize.Error.Insts.CoreConvertFromPolynomialError.from`:

- The call always succeeds (no panic).
- The result is the constant `serialize.Error.EncodingDecoding`, regardless of the input `PolynomialError` (the input error is discarded, unlike the analogous `EncodingError` conversion in #161 which wraps it).

Verified with `lake build Spqr.Specs.Serialize.Error.From` on top of `main` (7f0617a): build completed successfully; the only `sorry` warnings are pre-existing ones in `SrcTranslated/Funs.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)