### PR TITLE
Specify and verify: `spqr::v1::chunked::states::serialize::MAX_VARINT_BYTES_LEN` in `v1/chunked/states/serialize.rs`

### DIFF
--- a/Spqr.lean
+++ b/Spqr.lean
@@ -115,3 +115,4 @@ import Spqr.Specs.Serialize.Error.From
 import Spqr.Specs.Util.Compare
 import Spqr.Specs.Util.Inz
 import Spqr.Specs.Util.IsNonZero
+import Spqr.Specs.V1.Chunked.States.Serialize.MAX_VARINT_BYTES_LEN

--- a/Spqr/Specs/V1/Chunked/States/Serialize/MAX_VARINT_BYTES_LEN.lean
+++ b/Spqr/Specs/V1/Chunked/States/Serialize/MAX_VARINT_BYTES_LEN.lean
@@ -1,0 +1,28 @@
+/-
+Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Liao Zhang
+-/
+import SrcTranslated.Funs
+
+/-! # Spec theorem for `spqr::v1::chunked::states::serialize::MAX_VARINT_BYTES_LEN`
+
+`MAX_VARINT_BYTES_LEN` is the maximum number of bytes a LEB128-style varint encoding of a `u64`
+can occupy: each byte carries 7 payload bits, so a 64-bit value needs at most `⌈64 / 7⌉ = 10`
+bytes. `encode_varint` and `decode_varint` use it to bound their loops.
+
+This constant records that bound: `MAX_VARINT_BYTES_LEN = 10#usize`
+
+**Source**: src/v1/chunked/states/serialize.rs -/
+
+namespace spqr.v1.chunked.states.serialize
+
+/-- **Spec theorem for `v1.chunked.states.serialize.MAX_VARINT_BYTES_LEN`**:
+
+Concretely: `MAX_VARINT_BYTES_LEN.val = 10` -/
+@[simp]
+theorem MAX_VARINT_BYTES_LEN_val :
+    MAX_VARINT_BYTES_LEN.val = 10 := by
+  simp [MAX_VARINT_BYTES_LEN]
+
+end spqr.v1.chunked.states.serialize


### PR DESCRIPTION
Closes #307

Adds the spec theorem `MAX_VARINT_BYTES_LEN_val` proving `MAX_VARINT_BYTES_LEN.val = 10`, following the existing pattern for plain `Usize` constants (e.g. `CHUNK_SIZE`, `MACSIZE`). This is the first spec under the new `Spqr/Specs/V1/` directory tree.

Verified with `lake build Spqr` (2399 jobs, no errors).