### PR TITLE
Specify and verify: `spqr::v1::chunked::states::serialize::{spqr::v1::chunked::states::serialize::MessageType}::from_payload` in `v1/chunked/states/serialize.rs`

### DIFF
--- a/Spqr.lean
+++ b/Spqr.lean
@@ -123,3 +123,4 @@ import Spqr.Specs.Util.Compare
 import Spqr.Specs.Util.Inz
 import Spqr.Specs.Util.IsNonZero
 import Spqr.Specs.V1.Chunked.States.Serialize.MAX_VARINT_BYTES_LEN
+import Spqr.Specs.V1.Chunked.States.Serialize.MessageType.FromPayload

--- a/Spqr/Specs/V1/Chunked/States/Serialize/MessageType/FromPayload.lean
+++ b/Spqr/Specs/V1/Chunked/States/Serialize/MessageType/FromPayload.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Liao Zhang
+-/
+import SrcTranslated.Funs
+
+/-! # Spec theorem for
+`spqr::v1::chunked::states::serialize::{spqr::v1::chunked::states::serialize::MessageType}`
+`::from_payload`
+
+`from_payload` classifies a `MessagePayload` by returning the `MessageType` tag corresponding
+to its variant. It ignores the payload contents entirely and maps each `MessagePayload` variant
+to the like-named `MessageType` variant.
+
+**Source**: src/v1/chunked/states/serialize.rs (lines 124:4-134:5)
+-/
+
+open Aeneas Aeneas.Std Result
+
+namespace spqr.v1.chunked.states.serialize.MessageType
+
+/-- **Spec theorem for
+`v1.chunked.states.serialize.MessageType.from_payload`**:
+
+• The call always succeeds (no panic / no error) for any input `mp`.
+• The resulting `MessageType` is the tag of `mp`: each `MessagePayload` variant maps to the
+  identically-named `MessageType` variant, discarding any payload data. -/
+@[step]
+theorem from_payload_spec (mp : v1.chunked.states.MessagePayload) :
+    from_payload mp ⦃ (result : v1.chunked.states.serialize.MessageType) =>
+      result = match mp with
+        | .None => .None
+        | .Hdr _ => .Hdr
+        | .Ek _ => .Ek
+        | .EkCt1Ack _ => .EkCt1Ack
+        | .Ct1Ack _ => .Ct1Ack
+        | .Ct1 _ => .Ct1
+        | .Ct2 _ => .Ct2 ⦄ := by
+  match mp with
+  | .None | .Hdr _ | .Ek _ | .EkCt1Ack _ | .Ct1Ack _ | .Ct1 _ | .Ct2 _ =>
+    simp only [from_payload, WP.spec_ok]
+
+end spqr.v1.chunked.states.serialize.MessageType


### PR DESCRIPTION
This PR specifies and verifies `spqr::v1::chunked::states::serialize::{spqr::v1::chunked::states::serialize::MessageType}::from_payload` in `v1/chunked/states/serialize.rs`.

`from_payload` is a total function that classifies a `MessagePayload` by returning the `MessageType` tag corresponding to its variant. It discards the payload contents and maps each `MessagePayload` variant to the identically-named `MessageType` variant. The spec theorem `from_payload_spec` states that the call always succeeds (no panic / no error) and that the result is the tag of the input payload. The proof splits on the seven variants and closes each with `simp only [from_payload, WP.spec_ok]`.

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)