### PR TITLE
Specify and verify: `spqr::serialize::{impl core::clone::Clone for spqr::serialize::Error}::clone` in `serialize.rs`

### DIFF
--- a/Spqr.lean
+++ b/Spqr.lean
@@ -117,6 +117,7 @@ import Spqr.Specs.Encoding.Polynomial.Pt.PartialCmp
 import Spqr.Specs.Encoding.Polynomial.Pt.Serialize
 import Spqr.Specs.IncrementalMlkem768.FlipEndianness
 import Spqr.Specs.IncrementalMlkem768.Generate
+import Spqr.Specs.Serialize.Error.Clone
 import Spqr.Specs.Serialize.Error.Eq
 import Spqr.Specs.Serialize.Error.From
 import Spqr.Specs.Util.Compare

--- a/Spqr/Specs/Serialize/Error/Clone.lean
+++ b/Spqr/Specs/Serialize/Error/Clone.lean
@@ -1,0 +1,31 @@
+/-
+Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Liao Zhang
+-/
+import SrcTranslated.Funs
+
+/-! # Spec theorem for
+`spqr::serialize::{impl core::clone::Clone for spqr::serialize::Error}::clone`
+
+The derived `Clone` for the fieldless enum `serialize::Error` returns a copy of the input
+value. Since the enum carries no data, the clone is exactly the input.
+
+**Source**: src/serialize.rs (line 6, `#[derive(..., Clone)]`)
+-/
+
+open Aeneas Aeneas.Std Result
+
+namespace spqr.serialize.Error.Insts.CoreCloneClone
+
+/-- **Spec theorem for `serialize.Error.Insts.CoreCloneClone.clone`**:
+
+The derived `Clone for Error` always succeeds (no panic) and returns a value equal to its
+input: `clone self = ok self`. -/
+@[step]
+theorem clone_spec (self : serialize.Error) :
+    clone self ⦃ (result : serialize.Error) =>
+      result = self ⦄ := by
+  simp only [clone, WP.spec_ok]
+
+end spqr.serialize.Error.Insts.CoreCloneClone


### PR DESCRIPTION
This PR specifies and verifies `spqr::serialize::{impl core::clone::Clone for spqr::serialize::Error}::clone` in `serialize.rs`.

The `Clone` implementation is derived by `#[derive(Clone)]` on the fieldless enum `serialize::Error`. Since the enum carries no data, the clone is exactly the input value. The spec theorem `clone_spec` states that the call always succeeds (no panic) and returns a value equal to its input (`clone self = ok self`). The proof closes with `simp only [clone, WP.spec_ok]`.

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)