### PR TITLE
Specify and verify: `spqr::v1::chunked::states::serialize::encode_chunk` in `v1/chunked/states/serialize.rs`

### DIFF
--- a/Spqr.lean
+++ b/Spqr.lean
@@ -139,6 +139,7 @@ import Spqr.Specs.Util.Compare
 import Spqr.Specs.Util.Inz
 import Spqr.Specs.Util.IsNonZero
 import Spqr.Specs.V1.Chunked.States.Serialize.DecodeVarint
+import Spqr.Specs.V1.Chunked.States.Serialize.EncodeChunk
 import Spqr.Specs.V1.Chunked.States.Serialize.EncodeVarint
 import Spqr.Specs.V1.Chunked.States.Serialize.MAX_VARINT_BYTES_LEN
 import Spqr.Specs.V1.Chunked.States.Serialize.MessageType.FromPayload

--- a/Spqr.lean
+++ b/Spqr.lean
@@ -41,6 +41,7 @@ import Spqr.Math.Poly.LinearFactors.Degree
 import Spqr.Math.Poly.ModByMonic
 import Spqr.Specs.Aeneas.FmtArgumentsFromStr
 import Spqr.Specs.Aeneas.GF16New
+import Spqr.Specs.Aeneas.IndexRangeFull
 import Spqr.Specs.Aeneas.IntoIteratorSlice
 import Spqr.Specs.Aeneas.MapIteratorTransformerNext
 import Spqr.Specs.Aeneas.RangeIteratorNext

--- a/Spqr/Specs/Aeneas/IndexRangeFull.lean
+++ b/Spqr/Specs/Aeneas/IndexRangeFull.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Hoang Le Truong, Liao Zhang
+-/
+import SrcTranslated.Funs
+
+/-!
+# `simp`/`step_simps` lemma for `RangeFull` indexing of an array
+
+Indexing an array by `..` yields the whole array as a slice.  This is definitional, but
+registering it in the `simp` and `step_simps` sets lets `step*` see through the `a[..]` calls
+that appear whenever Rust code passes a fixed-size array to a slice-taking function.
+
+The slice-level counterpart (`s[..] = s`) already has a `@[step]` spec in
+`SrcTranslated.FunsExternal`.  Both are analogues of the upstream
+`Aeneas.Std.Array.index_SliceIndexRangeUsizeSlice` and should eventually be upstreamed to Aeneas.
+-/
+
+-- `spqr` is opened for the `RangeFull` `SliceIndex` instance record, which the extraction places
+-- in the crate namespace even though its `index` method is at the root.
+open Aeneas Aeneas.Std Result spqr
+
+/-- `RangeFull` indexing of an array yields the whole array as a slice: `a[..] = a`. -/
+@[simp, step_simps]
+theorem Aeneas.Std.Array.index_RangeFull {T : Type} {N : Usize} (a : Array T N) :
+    core.array.Array.index
+      (core.ops.index.IndexSlice
+        (core.ops.range.RangeFull.Insts.CoreSliceIndexSliceIndexSliceSlice T))
+      a () =
+    ok a.to_slice :=
+  rfl

--- a/Spqr/Specs/Encoding/Polynomial/Pt/Serialize.lean
+++ b/Spqr/Specs/Encoding/Polynomial/Pt/Serialize.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE-APACHE.
 Authors: Hoang Le Truong
 -/
 import SrcTranslated.Funs
+import Spqr.Specs.Aeneas.IndexRangeFull
 
 /-! # Spec Theorem for `Pt::serialize`
 
@@ -56,23 +57,6 @@ natural language specs:
 • Together with `Pt::deserialize`, the encoding is invertible:
     `Pt::deserialize(pt.serialize()) = ok pt`
 -/
-
-/-- `RangeFull` indexing on a slice is the identity: `slice[..] = slice`. -/
-private theorem rangeFull_index_eq {T : Type}
-    (r : core.ops.range.RangeFull) (s : Slice T) :
-    core.ops.range.RangeFull.Insts.CoreSliceIndexSliceIndexSliceSlice.index r s =
-    ok s := by
-  rfl
-
-@[simp, step_simps]
-private theorem array_index_rangeFull_ok {T : Type} {N : Usize}
-    (a : Array T N) :
-    core.array.Array.index
-      (core.ops.index.IndexSlice
-        (core.ops.range.RangeFull.Insts.CoreSliceIndexSliceIndexSliceSlice T))
-      a () =
-    ok a.to_slice :=
-  rangeFull_index_eq () a.to_slice
 
 /- **Spec for `U16::to_be_bytes`**:
 The two-byte big-endian encoding of a `u16` value `x` satisfies

--- a/Spqr/Specs/V1/Chunked/States/Serialize/EncodeChunk.lean
+++ b/Spqr/Specs/V1/Chunked/States/Serialize/EncodeChunk.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE-APACHE.
 Authors: Liao Zhang
 -/
 import SrcTranslated.Funs
+import Spqr.Specs.Aeneas.IndexRangeFull
 import Spqr.Specs.Aeneas.VecExtendFromSlice
 import Spqr.Specs.V1.Chunked.States.Serialize.EncodeVarint
 
@@ -18,10 +19,13 @@ i.e. the LEB128 encoding of the index (1–3 bytes for a `u16`, see `varintBytes
 verbatim by the payload bytes.
 
 We prove functional correctness: the result is exactly `into` extended by those two blocks,
-with nothing dropped or reordered.  The precondition `into.len() + 42 ≤ usize::MAX` covers
-both the pushes of `encode_varint` (at most 10 bytes) and the 32-byte `extend_from_slice`;
-it is the Lean counterpart of the `hax_lib::assume!(into.len() < usize::MAX - 32)` in the
-Rust source.
+with nothing dropped or reordered.  The precondition `into.len() + 42 ≤ usize::MAX` covers both
+the pushes of `encode_varint` (at most 10 bytes) and the 32-byte `extend_from_slice`.  It is
+stated on the *entry* buffer, so it is strictly stronger than — and implies — the mid-function
+`hax_lib::assume!(into.len() < usize::MAX - 32)` of the Rust source, which constrains the buffer
+only after the varint has been pushed.  Since the varint of a `u16` is at most 3 bytes, `+ 35`
+would in fact suffice; `+ 42` is what lets `step*` discharge the `extend_from_slice` overflow
+guard from `encode_varint_spec`'s generic 10-byte bound alone.
 
 **Source**: src/v1/chunked/states/serialize.rs (lines 184-188)
 -/
@@ -29,21 +33,6 @@ Rust source.
 open Aeneas Aeneas.Std Result
 
 namespace spqr.v1.chunked.states.serialize
-
-/-- `RangeFull` indexing of an array yields the whole array as a slice: `a[..] = a`. -/
-@[local simp, local step_simps]
-private theorem array_index_rangeFull_ok {T : Type} {N : Usize} (a : Array T N) :
-    core.array.Array.index
-      (core.ops.index.IndexSlice
-        (core.ops.range.RangeFull.Insts.CoreSliceIndexSliceIndexSliceSlice T))
-      a () =
-    ok a.to_slice :=
-  rfl
-
-/-- A `u16` index encodes in at most 3 varint bytes: `2 ^ 16 ≤ 2 ^ (7 * 3)`. -/
-theorem varintBytes_length_le_three {a : ℕ} (h : a < 2 ^ 16) :
-    (varintBytes a).length ≤ 3 :=
-  varintBytes_length_le 3 a (by omega) (lt_of_lt_of_le h (by norm_num))
 
 /-- **Spec theorem for `spqr::v1::chunked::states::serialize::encode_chunk`**:
 
@@ -68,10 +57,10 @@ theorem encode_chunk_spec
   have h_tail3 : into1.length ≤ 3 := by
     have h3 := varintBytes_length_le_three (a := i.val) (by scalar_tac)
     have hlen_eq := congrArg List.length into1_post2
-    simp at hlen_eq
+    simp only [List.length_map] at hlen_eq
     omega
   refine ⟨into1, ?_, by rw [into1_post2, hi], into1_post3, h_tail3⟩
   rw [out_post, into1_post1]
-  simp
+  simp only [Array.val_to_slice, List.append_assoc]
 
 end spqr.v1.chunked.states.serialize

--- a/Spqr/Specs/V1/Chunked/States/Serialize/EncodeChunk.lean
+++ b/Spqr/Specs/V1/Chunked/States/Serialize/EncodeChunk.lean
@@ -1,0 +1,77 @@
+/-
+Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Liao Zhang
+-/
+import SrcTranslated.Funs
+import Spqr.Specs.Aeneas.VecExtendFromSlice
+import Spqr.Specs.V1.Chunked.States.Serialize.EncodeVarint
+
+/-! # Spec theorem for `spqr::v1::chunked::states::serialize::encode_chunk`
+
+`encode_chunk` appends the wire encoding of a `Chunk` to the byte buffer `into`.  A chunk is
+a 16-bit index together with a fixed 32-byte payload, and it is serialized as
+
+  `[varint(index)] ++ [data (32 bytes)]`
+
+i.e. the LEB128 encoding of the index (1–3 bytes for a `u16`, see `varintBytes`) followed
+verbatim by the payload bytes.
+
+We prove functional correctness: the result is exactly `into` extended by those two blocks,
+with nothing dropped or reordered.  The precondition `into.len() + 42 ≤ usize::MAX` covers
+both the pushes of `encode_varint` (at most 10 bytes) and the 32-byte `extend_from_slice`;
+it is the Lean counterpart of the `hax_lib::assume!(into.len() < usize::MAX - 32)` in the
+Rust source.
+
+**Source**: src/v1/chunked/states/serialize.rs (lines 184-188)
+-/
+
+open Aeneas Aeneas.Std Result
+
+namespace spqr.v1.chunked.states.serialize
+
+/-- `RangeFull` indexing of an array yields the whole array as a slice: `a[..] = a`. -/
+@[local simp, local step_simps]
+private theorem array_index_rangeFull_ok {T : Type} {N : Usize} (a : Array T N) :
+    core.array.Array.index
+      (core.ops.index.IndexSlice
+        (core.ops.range.RangeFull.Insts.CoreSliceIndexSliceIndexSliceSlice T))
+      a () =
+    ok a.to_slice :=
+  rfl
+
+/-- A `u16` index encodes in at most 3 varint bytes: `2 ^ 16 ≤ 2 ^ (7 * 3)`. -/
+theorem varintBytes_length_le_three {a : ℕ} (h : a < 2 ^ 16) :
+    (varintBytes a).length ≤ 3 :=
+  varintBytes_length_le 3 a (by omega) (lt_of_lt_of_le h (by norm_num))
+
+/-- **Spec theorem for `spqr::v1::chunked::states::serialize::encode_chunk`**:
+
+Under the no-overflow precondition `into.len() + 42 ≤ usize::MAX`, `encode_chunk c into`
+succeeds and returns `into ++ tail ++ c.data`, where `tail` (read as natural-number byte
+values) is exactly `varintBytes c.index`, the LEB128 encoding of the chunk index — between
+1 and 3 bytes, since the index is a `u16`.  The 32-byte payload is appended unchanged. -/
+@[step]
+theorem encode_chunk_spec
+    (c : encoding.Chunk) (into : alloc.vec.Vec Std.U8)
+    (hlen : into.length + 42 ≤ Std.Usize.max) :
+    encode_chunk c into ⦃ (out : alloc.vec.Vec Std.U8) =>
+      ∃ tail, out.val = into.val ++ tail ++ c.data.val ∧
+        tail.map UScalar.val = varintBytes c.index.val ∧
+        1 ≤ tail.length ∧ tail.length ≤ 3 ⦄ := by
+  unfold encode_chunk
+  -- `step*` runs the two calls: `encode_varint` (giving the varint block `into1`) and
+  -- `extend_from_slice` (appending the payload); both overflow guards follow from `hlen`.
+  step*
+  -- `i` is the `u16` index widened to `u64`, so it has the same value.
+  have hi : i.val = c.index.val := by scalar_tac
+  have h_tail3 : into1.length ≤ 3 := by
+    have h3 := varintBytes_length_le_three (a := i.val) (by scalar_tac)
+    have hlen_eq := congrArg List.length into1_post2
+    simp at hlen_eq
+    omega
+  refine ⟨into1, ?_, by rw [into1_post2, hi], into1_post3, h_tail3⟩
+  rw [out_post, into1_post1]
+  simp
+
+end spqr.v1.chunked.states.serialize

--- a/Spqr/Specs/V1/Chunked/States/Serialize/EncodeVarint.lean
+++ b/Spqr/Specs/V1/Chunked/States/Serialize/EncodeVarint.lean
@@ -66,6 +66,11 @@ theorem varintBytes_length_le : ∀ (n a : ℕ), 1 ≤ n → a < 2 ^ (7 * n) →
       simp only [List.length_cons]
       omega
 
+/-- A `u16` value encodes in at most 3 bytes: `2 ^ 16 ≤ 2 ^ (7 * 3)`. -/
+theorem varintBytes_length_le_three {a : ℕ} (h : a < 2 ^ 16) : (varintBytes a).length ≤ 3 :=
+  varintBytes_length_le 3 a (by omega)
+    (lt_of_lt_of_le h (by norm_num))
+
 /-- A `u64` value encodes in at most 10 bytes. -/
 theorem varintBytes_length_le_ten {a : ℕ} (h : a < 2 ^ 64) : (varintBytes a).length ≤ 10 :=
   varintBytes_length_le 10 a (by omega)


### PR DESCRIPTION
This PR specifies and verifies `spqr::v1::chunked::states::serialize::encode_chunk`
(`src/v1/chunked/states/serialize.rs`, lines 184-188), the serializer that appends the wire
encoding of a `Chunk` to a byte buffer. A chunk is a 16-bit index plus a fixed 32-byte
payload, and it goes on the wire as `varint(index) ++ data`.

The spec theorem `encode_chunk_spec` concludes that `encode_chunk c into` succeeds and returns
`into ++ tail ++ c.data` with `tail.map UScalar.val = varintBytes c.index.val` and
`1 ≤ tail.length ≤ 3`, i.e. nothing is dropped or reordered and the payload is appended
unchanged. The proof runs the two calls with `step*` and composes `encode_varint_spec` (#311)
with `Vec.extend_from_slice`.

The no-overflow precondition is `into.len() + 42 ≤ usize::MAX`, covering both the at-most-10
pushes of `encode_varint` and the 32-byte `extend_from_slice`. Note it is stated on the *entry*
buffer, so it is strictly stronger than — and implies — the Rust
`hax_lib::assume!(into.len() < usize::MAX - 32)`, which sits mid-function and constrains the
buffer only after the varint has been pushed. Since a `u16` varint is at most 3 bytes, `+ 35`
would in fact suffice; `+ 42` is what lets `step*` discharge the `extend_from_slice` overflow
guard from `encode_varint_spec`'s generic 10-byte bound alone. This trade-off is documented in
the module docstring.

Two supporting lemmas are placed centrally rather than locally, since both are reusable (the
first will be needed by a future `decode_chunk` spec):

- `varintBytes_length_le_three` — the generic length bound specialised to a `u16` argument
  (`2 ^ 16 ≤ 2 ^ (7 * 3)`) — lives in `EncodeVarint.lean` next to `varintBytes_length_le_ten`,
  alongside the pure model it is about.
- `Aeneas.Std.Array.index_RangeFull` — `RangeFull` indexing of an array (`a[..] = a`), by `rfl`
  — is the new shared `Spqr/Specs/Aeneas/IndexRangeFull.lean`. An identical lemma already
  existed privately in `Spqr/Specs/Encoding/Polynomial/Pt/Serialize.lean`; that copy and its
  slice-level helper are removed and the file now imports the shared one (`FunsExternal`
  already provides a `@[step]` spec for the slice-level `s[..] = s`). Name and
  `@[simp, step_simps]` attributes follow the upstream
  `Aeneas.Std.Array.index_SliceIndexRangeUsizeSlice`, so this is upstreamable to Aeneas.

No `sorry`, no new axioms: beyond the standard three, the theorem depends only on the
pre-existing extracted-model axioms `RangeFull...get_unchecked{,_mut}` in
`SrcTranslated/FunsExternal.lean`, pulled in by the `RangeFull` slice-index instance. The axiom
closures of `encode_chunk_spec` and `Pt.serialize_spec` are unchanged by the refactor; those two
externals now enter through a single centralised lemma instead of two duplicates. `lake build`
and `lake exe runLinter Spqr` both pass against current `main`.

Closes #313
