### PR TITLE
Specify and verify unchunked send_ek `KeysUnsampled::into_pb`

### DIFF
--- a/Spqr.lean
+++ b/Spqr.lean
@@ -154,3 +154,4 @@ import Spqr.Specs.V1.Chunked.States.Serialize.Message.Serialize
 import Spqr.Specs.V1.Chunked.States.Serialize.MessageType.FromPayload
 import Spqr.Specs.V1.Chunked.States.Serialize.MessageType.TryFrom
 import Spqr.Specs.V1.Chunked.States.Serialize.U8.From
+import Spqr.Specs.V1.Unchunked.SendEk.Serialize.KeysUnsampled.IntoPb

--- a/Spqr/Specs/V1/Unchunked/SendEk/Serialize/KeysUnsampled/IntoPb.lean
+++ b/Spqr/Specs/V1/Unchunked/SendEk/Serialize/KeysUnsampled/IntoPb.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Liao Zhang
+-/
+import SrcTranslated.Funs
+
+/-! # Spec theorem for `spqr::v1::unchunked::send_ek::serialize::KeysUnsampled::into_pb`
+
+Converts a `KeysUnsampled` state from the in-memory Rust form
+(`v1.unchunked.send_ek.KeysUnsampled`) into the protobuf form
+(`proto.pq_ratchet.v1_state.unchunked.KeysUnsampled`) used for saving it to
+disk. The `epoch` field is copied over unchanged and the `auth` field is
+converted with `Authenticator::into_pb` (a plain field copy) and wrapped in
+`Some`. The reverse direction is `from_pb`.
+
+**Source**: src/v1/unchunked/send_ek/serialize.rs (lines 10:4-15:5)
+-/
+
+open Aeneas Aeneas.Std Result
+
+namespace spqr.v1.unchunked.send_ek.serialize.KeysUnsampled
+
+/-- **Spec theorem for `v1.unchunked.send_ek.serialize.KeysUnsampled.into_pb`**:
+
+• The call always succeeds (no panic).
+• The result's `epoch` equals `self.epoch`.
+• The result's `auth` is `some` of the protobuf form of `self.auth`,
+  carrying the same `root_key` and `mac_key`. -/
+@[step]
+theorem into_pb_spec (self : v1.unchunked.send_ek.KeysUnsampled) :
+    into_pb self ⦃ (result : proto.pq_ratchet.v1_state.unchunked.KeysUnsampled) =>
+      result.epoch = self.epoch ∧
+      result.auth = some { root_key := self.auth.root_key,
+                           mac_key := self.auth.mac_key } ⦄ := by
+  simp [into_pb, authenticator.serialize.Authenticator.into_pb]
+
+end spqr.v1.unchunked.send_ek.serialize.KeysUnsampled


### PR DESCRIPTION
Adds a precondition-free spec theorem for `spqr::v1::unchunked::send_ek::serialize::KeysUnsampled::into_pb`:

- The call always succeeds (no panic).
- `epoch` is copied verbatim.
- `auth` is `some` of the protobuf form, with `root_key`/`mac_key` preserved.

Proof is a one-line `simp` unfolding the two field-copy bodies. Tagged `@[step]` for reuse by the chunked layer and the future `States::into_pb` spec (#317).

Closes #376. Parent: #375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)