### PR TITLE
Specify and verify unchunked send_ek `into_pb` (all four states)

### DIFF
--- a/Spqr.lean
+++ b/Spqr.lean
@@ -154,3 +154,4 @@ import Spqr.Specs.V1.Chunked.States.Serialize.Message.Serialize
 import Spqr.Specs.V1.Chunked.States.Serialize.MessageType.FromPayload
 import Spqr.Specs.V1.Chunked.States.Serialize.MessageType.TryFrom
 import Spqr.Specs.V1.Chunked.States.Serialize.U8.From
+import Spqr.Specs.V1.Unchunked.SendEk.Serialize.HeaderSent.IntoPb

--- a/Spqr.lean
+++ b/Spqr.lean
@@ -157,3 +157,4 @@ import Spqr.Specs.V1.Chunked.States.Serialize.U8.From
 import Spqr.Specs.V1.Unchunked.SendEk.Serialize.EkSent.IntoPb
 import Spqr.Specs.V1.Unchunked.SendEk.Serialize.EkSentCt1Received.IntoPb
 import Spqr.Specs.V1.Unchunked.SendEk.Serialize.HeaderSent.IntoPb
+import Spqr.Specs.V1.Unchunked.SendEk.Serialize.KeysUnsampled.IntoPb

--- a/Spqr.lean
+++ b/Spqr.lean
@@ -154,4 +154,6 @@ import Spqr.Specs.V1.Chunked.States.Serialize.Message.Serialize
 import Spqr.Specs.V1.Chunked.States.Serialize.MessageType.FromPayload
 import Spqr.Specs.V1.Chunked.States.Serialize.MessageType.TryFrom
 import Spqr.Specs.V1.Chunked.States.Serialize.U8.From
+import Spqr.Specs.V1.Unchunked.SendEk.Serialize.EkSent.IntoPb
+import Spqr.Specs.V1.Unchunked.SendEk.Serialize.EkSentCt1Received.IntoPb
 import Spqr.Specs.V1.Unchunked.SendEk.Serialize.HeaderSent.IntoPb

--- a/Spqr/Specs/V1/Unchunked/SendEk/Serialize/EkSent/IntoPb.lean
+++ b/Spqr/Specs/V1/Unchunked/SendEk/Serialize/EkSent/IntoPb.lean
@@ -1,0 +1,39 @@
+/-
+Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Liao Zhang
+-/
+import SrcTranslated.Funs
+
+/-! # Spec theorem for `spqr::v1::unchunked::send_ek::serialize::EkSent::into_pb`
+
+Converts an `EkSent` state from the in-memory Rust form
+(`v1.unchunked.send_ek.EkSent`) into the protobuf form
+(`proto.pq_ratchet.v1_state.unchunked.EkSent`) used for saving it to disk.
+The `epoch` and `dk` (decapsulation key) fields are copied over unchanged
+and the `auth` field is converted with `Authenticator::into_pb` (a plain
+field copy) and wrapped in `Some`. The reverse direction is `from_pb`.
+
+**Source**: src/v1/unchunked/send_ek/serialize.rs (lines 50:4-56:5)
+-/
+
+open Aeneas Aeneas.Std Result
+
+namespace spqr.v1.unchunked.send_ek.serialize.EkSent
+
+/-- **Spec theorem for `v1.unchunked.send_ek.serialize.EkSent.into_pb`**:
+
+• The call always succeeds (no panic).
+• The result's `epoch` and `dk` equal the corresponding fields of `self`.
+• The result's `auth` is `some` of the protobuf form of `self.auth`,
+  carrying the same `root_key` and `mac_key`. -/
+@[step]
+theorem into_pb_spec (self : v1.unchunked.send_ek.EkSent) :
+    into_pb self ⦃ (result : proto.pq_ratchet.v1_state.unchunked.EkSent) =>
+      result.epoch = self.epoch ∧
+      result.dk = self.dk ∧
+      result.auth = some { root_key := self.auth.root_key,
+                           mac_key := self.auth.mac_key } ⦄ := by
+  simp [into_pb, authenticator.serialize.Authenticator.into_pb]
+
+end spqr.v1.unchunked.send_ek.serialize.EkSent

--- a/Spqr/Specs/V1/Unchunked/SendEk/Serialize/EkSentCt1Received/IntoPb.lean
+++ b/Spqr/Specs/V1/Unchunked/SendEk/Serialize/EkSentCt1Received/IntoPb.lean
@@ -1,0 +1,41 @@
+/-
+Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Liao Zhang
+-/
+import SrcTranslated.Funs
+
+/-! # Spec theorem for `spqr::v1::unchunked::send_ek::serialize::EkSentCt1Received::into_pb`
+
+Converts an `EkSentCt1Received` state from the in-memory Rust form
+(`v1.unchunked.send_ek.EkSentCt1Received`) into the protobuf form
+(`proto.pq_ratchet.v1_state.unchunked.EkSentCt1Received`) used for saving
+it to disk. The `epoch`, `dk` (decapsulation key) and `ct1` (first
+ciphertext) fields are copied over unchanged and the `auth` field is
+converted with `Authenticator::into_pb` (a plain field copy) and wrapped
+in `Some`. The reverse direction is `from_pb`.
+
+**Source**: src/v1/unchunked/send_ek/serialize.rs (lines 72:4-79:5)
+-/
+
+open Aeneas Aeneas.Std Result
+
+namespace spqr.v1.unchunked.send_ek.serialize.EkSentCt1Received
+
+/-- **Spec theorem for `v1.unchunked.send_ek.serialize.EkSentCt1Received.into_pb`**:
+
+• The call always succeeds (no panic).
+• The result's `epoch`, `dk` and `ct1` equal the corresponding fields of `self`.
+• The result's `auth` is `some` of the protobuf form of `self.auth`,
+  carrying the same `root_key` and `mac_key`. -/
+@[step]
+theorem into_pb_spec (self : v1.unchunked.send_ek.EkSentCt1Received) :
+    into_pb self ⦃ (result : proto.pq_ratchet.v1_state.unchunked.EkSentCt1Received) =>
+      result.epoch = self.epoch ∧
+      result.dk = self.dk ∧
+      result.ct1 = self.ct1 ∧
+      result.auth = some { root_key := self.auth.root_key,
+                           mac_key := self.auth.mac_key } ⦄ := by
+  simp [into_pb, authenticator.serialize.Authenticator.into_pb]
+
+end spqr.v1.unchunked.send_ek.serialize.EkSentCt1Received

--- a/Spqr/Specs/V1/Unchunked/SendEk/Serialize/HeaderSent/IntoPb.lean
+++ b/Spqr/Specs/V1/Unchunked/SendEk/Serialize/HeaderSent/IntoPb.lean
@@ -1,0 +1,41 @@
+/-
+Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Liao Zhang
+-/
+import SrcTranslated.Funs
+
+/-! # Spec theorem for `spqr::v1::unchunked::send_ek::serialize::HeaderSent::into_pb`
+
+Converts a `HeaderSent` state from the in-memory Rust form
+(`v1.unchunked.send_ek.HeaderSent`) into the protobuf form
+(`proto.pq_ratchet.v1_state.unchunked.HeaderSent`) used for saving it to
+disk. The `epoch`, `ek` (encapsulation key) and `dk` (decapsulation key)
+fields are copied over unchanged and the `auth` field is converted with
+`Authenticator::into_pb` (a plain field copy) and wrapped in `Some`. The
+reverse direction is `from_pb`.
+
+**Source**: src/v1/unchunked/send_ek/serialize.rs (lines 26:4-33:5)
+-/
+
+open Aeneas Aeneas.Std Result
+
+namespace spqr.v1.unchunked.send_ek.serialize.HeaderSent
+
+/-- **Spec theorem for `v1.unchunked.send_ek.serialize.HeaderSent.into_pb`**:
+
+• The call always succeeds (no panic).
+• The result's `epoch`, `ek` and `dk` equal the corresponding fields of `self`.
+• The result's `auth` is `some` of the protobuf form of `self.auth`,
+  carrying the same `root_key` and `mac_key`. -/
+@[step]
+theorem into_pb_spec (self : v1.unchunked.send_ek.HeaderSent) :
+    into_pb self ⦃ (result : proto.pq_ratchet.v1_state.unchunked.HeaderSent) =>
+      result.epoch = self.epoch ∧
+      result.ek = self.ek ∧
+      result.dk = self.dk ∧
+      result.auth = some { root_key := self.auth.root_key,
+                           mac_key := self.auth.mac_key } ⦄ := by
+  simp [into_pb, authenticator.serialize.Authenticator.into_pb]
+
+end spqr.v1.unchunked.send_ek.serialize.HeaderSent

--- a/Spqr/Specs/V1/Unchunked/SendEk/Serialize/KeysUnsampled/IntoPb.lean
+++ b/Spqr/Specs/V1/Unchunked/SendEk/Serialize/KeysUnsampled/IntoPb.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Liao Zhang
+-/
+import SrcTranslated.Funs
+
+/-! # Spec theorem for `spqr::v1::unchunked::send_ek::serialize::KeysUnsampled::into_pb`
+
+Converts a `KeysUnsampled` state from the in-memory Rust form
+(`v1.unchunked.send_ek.KeysUnsampled`) into the protobuf form
+(`proto.pq_ratchet.v1_state.unchunked.KeysUnsampled`) used for saving it to
+disk. The `epoch` field is copied over unchanged and the `auth` field is
+converted with `Authenticator::into_pb` (a plain field copy) and wrapped in
+`Some`. The reverse direction is `from_pb`.
+
+**Source**: src/v1/unchunked/send_ek/serialize.rs (lines 10:4-15:5)
+-/
+
+open Aeneas Aeneas.Std Result
+
+namespace spqr.v1.unchunked.send_ek.serialize.KeysUnsampled
+
+/-- **Spec theorem for `v1.unchunked.send_ek.serialize.KeysUnsampled.into_pb`**:
+
+• The call always succeeds (no panic).
+• The result's `epoch` equals `self.epoch`.
+• The result's `auth` is `some` of the protobuf form of `self.auth`,
+  carrying the same `root_key` and `mac_key`. -/
+@[step]
+theorem into_pb_spec (self : v1.unchunked.send_ek.KeysUnsampled) :
+    into_pb self ⦃ (result : proto.pq_ratchet.v1_state.unchunked.KeysUnsampled) =>
+      result.epoch = self.epoch ∧
+      result.auth = some { root_key := self.auth.root_key,
+                           mac_key := self.auth.mac_key } ⦄ := by
+  simp [into_pb, authenticator.serialize.Authenticator.into_pb]
+
+end spqr.v1.unchunked.send_ek.serialize.KeysUnsampled


### PR DESCRIPTION
Adds precondition-free spec theorems for the four `into_pb` conversions in `spqr::v1::unchunked::send_ek::serialize`:

- `KeysUnsampled::into_pb` (#376)
- `HeaderSent::into_pb` (#378)
- `EkSent::into_pb` (#380)
- `EkSentCt1Received::into_pb` (#382)

All four share the same shape:

- The call always succeeds (no panic).
- All plain fields (`epoch`, `ek`/`dk`/`ct1` as applicable) are copied verbatim.
- `auth` is `some` of the protobuf form, with `root_key`/`mac_key` preserved.

Proofs are one-line `simp`s unfolding the two field-copy bodies. Tagged `@[step]` for reuse by the chunked layer and the future `States::into_pb` spec (#317).

Closes #376. Closes #378. Closes #380. Closes #382. Parent: #375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
