### PR TITLE
Specify and verify unchunked send_ct serialize: remaining from_pb states

### DIFF
--- a/Spqr.lean
+++ b/Spqr.lean
@@ -165,9 +165,13 @@ import Spqr.Specs.V1.Chunked.States.Serialize.Message.Serialize
 import Spqr.Specs.V1.Chunked.States.Serialize.MessageType.FromPayload
 import Spqr.Specs.V1.Chunked.States.Serialize.MessageType.TryFrom
 import Spqr.Specs.V1.Chunked.States.Serialize.U8.From
+import Spqr.Specs.V1.Unchunked.SendCt.Serialize.Ct1Sent.FromPb
 import Spqr.Specs.V1.Unchunked.SendCt.Serialize.Ct1Sent.IntoPb
+import Spqr.Specs.V1.Unchunked.SendCt.Serialize.Ct1SentEkReceived.FromPb
 import Spqr.Specs.V1.Unchunked.SendCt.Serialize.Ct1SentEkReceived.IntoPb
+import Spqr.Specs.V1.Unchunked.SendCt.Serialize.Ct2Sent.FromPb
 import Spqr.Specs.V1.Unchunked.SendCt.Serialize.Ct2Sent.IntoPb
+import Spqr.Specs.V1.Unchunked.SendCt.Serialize.HeaderReceived.FromPb
 import Spqr.Specs.V1.Unchunked.SendCt.Serialize.HeaderReceived.IntoPb
 import Spqr.Specs.V1.Unchunked.SendCt.Serialize.NoHeaderReceived.FromPb
 import Spqr.Specs.V1.Unchunked.SendCt.Serialize.NoHeaderReceived.IntoPb

--- a/Spqr/Specs/V1/Unchunked/SendCt/Serialize/Ct1Sent/FromPb.lean
+++ b/Spqr/Specs/V1/Unchunked/SendCt/Serialize/Ct1Sent/FromPb.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Liao Zhang
+-/
+import SrcTranslated.Funs
+import Spqr.Specs.Authenticator.Serialize.Authenticator.FromPb
+
+/-! # Spec theorem for `spqr::v1::unchunked::send_ct::serialize::Ct1Sent::from_pb`
+
+Converts a `Ct1Sent` state from the protobuf form
+(`proto.pq_ratchet.v1_state.unchunked.Ct1Sent`) back into the in-memory
+Rust form (`v1.unchunked.send_ct.Ct1Sent`). The header `hdr` must be
+exactly 64 bytes, the encapsulation randomness `es` exactly 2080 bytes,
+the first ciphertext `ct1` exactly 960 bytes, and the optional `auth`
+field must be present (`Error::StateDecode` otherwise); `epoch`, `hdr`,
+`es` and `ct1` are copied verbatim and `auth` is converted with
+`Authenticator::from_pb` (a clone of the two key vectors). The reverse
+direction is `into_pb`.
+
+**Source**: src/v1/unchunked/send_ct/serialize.rs (lines 58:4-70:5)
+-/
+
+open Aeneas Aeneas.Std Result
+
+namespace spqr.v1.unchunked.send_ct.serialize.Ct1Sent
+
+/-- **Spec theorem for `v1.unchunked.send_ct.serialize.Ct1Sent.from_pb`**:
+
+• The call always succeeds (no panic).
+• If `hdr` is not 64 bytes long, `es` is not 2080 bytes long, `ct1` is not
+  960 bytes long, or `pb.auth` is missing, the result is
+  `Err Error.StateDecode`.
+• Otherwise the result is `Ok` with `epoch`, `hdr`, `es` and `ct1` copied
+  verbatim and the `auth` key vectors preserved. -/
+@[step]
+theorem from_pb_spec (pb : proto.pq_ratchet.v1_state.unchunked.Ct1Sent) :
+    from_pb pb ⦃ (result : core.result.Result v1.unchunked.send_ct.Ct1Sent Error) =>
+      if pb.hdr.length = 64 ∧ pb.es.length = 2080 ∧ pb.ct1.length = 960 then
+        match pb.auth with
+        | none => result = .Err Error.StateDecode
+        | some a =>
+          result = .Ok {
+            epoch := pb.epoch,
+            auth := { root_key := a.root_key, mac_key := a.mac_key },
+            hdr := pb.hdr, es := pb.es, ct1 := pb.ct1 }
+      else result = .Err Error.StateDecode ⦄ := by
+  unfold from_pb
+  by_cases hhdr : pb.hdr.length = 64
+  · rw [if_pos (by scalar_tac : alloc.vec.Vec.len pb.hdr = 64#usize)]
+    by_cases hes : pb.es.length = 2080
+    · rw [if_pos (by scalar_tac : alloc.vec.Vec.len pb.es = 2080#usize)]
+      by_cases hct : pb.ct1.length = 960
+      · rw [if_pos (by scalar_tac : alloc.vec.Vec.len pb.ct1 = 960#usize)]
+        simp only [hhdr, hes, hct, and_self, reduceIte]
+        match pb.auth with
+        | none =>
+          simp only [core.option.Option.as_ref, core.option.Option.ok_or,
+            core.result.Result.Insts.CoreOpsTry.branch,
+            core.result.Result.Insts.CoreOpsTryTraitFromResidualResultInfallible.from_residual,
+            core.convert.FromSame.from, bind_tc_ok, WP.spec_ok]
+        | some a' =>
+          simp only [core.option.Option.as_ref, core.option.Option.ok_or,
+            core.result.Result.Insts.CoreOpsTry.branch, bind_tc_ok]
+          step*
+          simp only [← a_post1, ← a_post2]
+      · rw [if_neg (by scalar_tac : ¬alloc.vec.Vec.len pb.ct1 = 960#usize)]
+        simp [hct, WP.spec_ok]
+    · rw [if_neg (by scalar_tac : ¬alloc.vec.Vec.len pb.es = 2080#usize)]
+      simp [hes, WP.spec_ok]
+  · rw [if_neg (by scalar_tac : ¬alloc.vec.Vec.len pb.hdr = 64#usize)]
+    simp [hhdr, WP.spec_ok]
+
+end spqr.v1.unchunked.send_ct.serialize.Ct1Sent

--- a/Spqr/Specs/V1/Unchunked/SendCt/Serialize/Ct1SentEkReceived/FromPb.lean
+++ b/Spqr/Specs/V1/Unchunked/SendCt/Serialize/Ct1SentEkReceived/FromPb.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Liao Zhang
+-/
+import SrcTranslated.Funs
+import Spqr.Specs.Authenticator.Serialize.Authenticator.FromPb
+
+/-! # Spec theorem for `spqr::v1::unchunked::send_ct::serialize::Ct1SentEkReceived::from_pb`
+
+Converts a `Ct1SentEkReceived` state from the protobuf form
+(`proto.pq_ratchet.v1_state.unchunked.Ct1SentEkReceived`) back into the
+in-memory Rust form (`v1.unchunked.send_ct.Ct1SentEkReceived`). The
+encapsulation randomness `es` must be exactly 2080 bytes, the first
+ciphertext `ct1` exactly 960 bytes, the encapsulation key `ek` exactly
+1152 bytes, and the optional `auth` field must be present
+(`Error::StateDecode` otherwise); `epoch`, `es`, `ek` and `ct1` are copied
+verbatim and `auth` is converted with `Authenticator::from_pb` (a clone of
+the two key vectors). The reverse direction is `into_pb`.
+
+**Source**: src/v1/unchunked/send_ct/serialize.rs (lines 84:4-96:5)
+-/
+
+open Aeneas Aeneas.Std Result
+
+namespace spqr.v1.unchunked.send_ct.serialize.Ct1SentEkReceived
+
+/-- **Spec theorem for `v1.unchunked.send_ct.serialize.Ct1SentEkReceived.from_pb`**:
+
+• The call always succeeds (no panic).
+• If `es` is not 2080 bytes long, `ct1` is not 960 bytes long, `ek` is not
+  1152 bytes long, or `pb.auth` is missing, the result is
+  `Err Error.StateDecode`.
+• Otherwise the result is `Ok` with `epoch`, `es`, `ek` and `ct1` copied
+  verbatim and the `auth` key vectors preserved. -/
+@[step]
+theorem from_pb_spec (pb : proto.pq_ratchet.v1_state.unchunked.Ct1SentEkReceived) :
+    from_pb pb ⦃ (result : core.result.Result v1.unchunked.send_ct.Ct1SentEkReceived Error) =>
+      if pb.es.length = 2080 ∧ pb.ct1.length = 960 ∧ pb.ek.length = 1152 then
+        match pb.auth with
+        | none => result = .Err Error.StateDecode
+        | some a =>
+          result = .Ok {
+            epoch := pb.epoch,
+            auth := { root_key := a.root_key, mac_key := a.mac_key },
+            es := pb.es, ek := pb.ek, ct1 := pb.ct1 }
+      else result = .Err Error.StateDecode ⦄ := by
+  unfold from_pb
+  by_cases hes : pb.es.length = 2080
+  · rw [if_pos (by scalar_tac : alloc.vec.Vec.len pb.es = 2080#usize)]
+    by_cases hct : pb.ct1.length = 960
+    · rw [if_pos (by scalar_tac : alloc.vec.Vec.len pb.ct1 = 960#usize)]
+      by_cases hek : pb.ek.length = 1152
+      · rw [if_pos (by scalar_tac : alloc.vec.Vec.len pb.ek = 1152#usize)]
+        simp only [hes, hct, hek, and_self, reduceIte]
+        match pb.auth with
+        | none =>
+          simp only [core.option.Option.as_ref, core.option.Option.ok_or,
+            core.result.Result.Insts.CoreOpsTry.branch,
+            core.result.Result.Insts.CoreOpsTryTraitFromResidualResultInfallible.from_residual,
+            core.convert.FromSame.from, bind_tc_ok, WP.spec_ok]
+        | some a' =>
+          simp only [core.option.Option.as_ref, core.option.Option.ok_or,
+            core.result.Result.Insts.CoreOpsTry.branch, bind_tc_ok]
+          step*
+          simp only [← a_post1, ← a_post2]
+      · rw [if_neg (by scalar_tac : ¬alloc.vec.Vec.len pb.ek = 1152#usize)]
+        simp [hek, WP.spec_ok]
+    · rw [if_neg (by scalar_tac : ¬alloc.vec.Vec.len pb.ct1 = 960#usize)]
+      simp [hct, WP.spec_ok]
+  · rw [if_neg (by scalar_tac : ¬alloc.vec.Vec.len pb.es = 2080#usize)]
+    simp [hes, WP.spec_ok]
+
+end spqr.v1.unchunked.send_ct.serialize.Ct1SentEkReceived

--- a/Spqr/Specs/V1/Unchunked/SendCt/Serialize/Ct2Sent/FromPb.lean
+++ b/Spqr/Specs/V1/Unchunked/SendCt/Serialize/Ct2Sent/FromPb.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Liao Zhang
+-/
+import SrcTranslated.Funs
+import Spqr.Specs.Authenticator.Serialize.Authenticator.FromPb
+
+/-! # Spec theorem for `spqr::v1::unchunked::send_ct::serialize::Ct2Sent::from_pb`
+
+Converts a `Ct2Sent` state from the protobuf form
+(`proto.pq_ratchet.v1_state.unchunked.Ct2Sent`) read from disk back into
+the in-memory Rust form (`v1.unchunked.send_ct.Ct2Sent`). The `epoch`
+field is copied over unchanged; the `auth` field must be present (`Some`)
+and is converted with `Authenticator::from_pb` (a clone of the two key
+vectors), otherwise the function returns `Err(Error::StateDecode)`.
+The reverse direction is `into_pb`.
+
+**Source**: src/v1/unchunked/send_ct/serialize.rs (lines 107:4-112:5)
+-/
+
+open Aeneas Aeneas.Std Result
+
+namespace spqr.v1.unchunked.send_ct.serialize.Ct2Sent
+
+/-- **Spec theorem for `v1.unchunked.send_ct.serialize.Ct2Sent.from_pb`**:
+
+• The call always succeeds (no panic) and never returns a spurious error.
+• If `pb.auth` is missing, the result is `Err Error.StateDecode`.
+• If `pb.auth = some a`, the result is `Ok` of the state with `epoch`
+  copied from `pb` and `auth` carrying the same `root_key` and `mac_key`
+  as `a`. -/
+@[step]
+theorem from_pb_spec (pb : proto.pq_ratchet.v1_state.unchunked.Ct2Sent) :
+    from_pb pb ⦃ (result : core.result.Result v1.unchunked.send_ct.Ct2Sent Error) =>
+      match pb.auth with
+      | none => result = .Err Error.StateDecode
+      | some a => result = .Ok { epoch := pb.epoch,
+                                 auth := { root_key := a.root_key,
+                                           mac_key := a.mac_key } } ⦄ := by
+  unfold from_pb
+  match pb.auth with
+  | none =>
+    simp [core.option.Option.as_ref, core.option.Option.ok_or,
+          core.result.Result.Insts.CoreOpsTry.branch,
+          core.result.Result.Insts.CoreOpsTryTraitFromResidualResultInfallible.from_residual,
+          core.convert.FromSame.from]
+  | some a' =>
+    simp only [core.option.Option.as_ref, core.option.Option.ok_or,
+               core.result.Result.Insts.CoreOpsTry.branch, bind_tc_ok]
+    step*
+    obtain ⟨root_key, mac_key⟩ := a
+    simp_all
+
+end spqr.v1.unchunked.send_ct.serialize.Ct2Sent

--- a/Spqr/Specs/V1/Unchunked/SendCt/Serialize/HeaderReceived/FromPb.lean
+++ b/Spqr/Specs/V1/Unchunked/SendCt/Serialize/HeaderReceived/FromPb.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Liao Zhang
+-/
+import SrcTranslated.Funs
+import Spqr.Specs.Authenticator.Serialize.Authenticator.FromPb
+
+/-! # Spec theorem for `spqr::v1::unchunked::send_ct::serialize::HeaderReceived::from_pb`
+
+Converts a `HeaderReceived` state from the protobuf form
+(`proto.pq_ratchet.v1_state.unchunked.HeaderReceived`) back into the
+in-memory Rust form (`v1.unchunked.send_ct.HeaderReceived`). The header
+`hdr` must be exactly 64 bytes and the optional `auth` field must be
+present (`Error::StateDecode` otherwise); `epoch` and `hdr` are copied
+verbatim and `auth` is converted with `Authenticator::from_pb` (a clone
+of the two key vectors). The reverse direction is `into_pb`.
+
+**Source**: src/v1/unchunked/send_ct/serialize.rs (lines 34:4-44:5)
+-/
+
+open Aeneas Aeneas.Std Result
+
+namespace spqr.v1.unchunked.send_ct.serialize.HeaderReceived
+
+/-- **Spec theorem for `v1.unchunked.send_ct.serialize.HeaderReceived.from_pb`**:
+
+• The call always succeeds (no panic).
+• If `hdr` is not 64 bytes long or `pb.auth` is missing, the result is
+  `Err Error.StateDecode`.
+• Otherwise the result is `Ok` with `epoch` and `hdr` copied verbatim and
+  the `auth` key vectors preserved. -/
+@[step]
+theorem from_pb_spec (pb : proto.pq_ratchet.v1_state.unchunked.HeaderReceived) :
+    from_pb pb ⦃ (result : core.result.Result v1.unchunked.send_ct.HeaderReceived Error) =>
+      if pb.hdr.length = 64 then
+        match pb.auth with
+        | none => result = .Err Error.StateDecode
+        | some a =>
+          result = .Ok {
+            epoch := pb.epoch,
+            auth := { root_key := a.root_key, mac_key := a.mac_key },
+            hdr := pb.hdr }
+      else result = .Err Error.StateDecode ⦄ := by
+  unfold from_pb
+  by_cases hhdr : pb.hdr.length = 64
+  · rw [if_pos (by scalar_tac : alloc.vec.Vec.len pb.hdr = 64#usize)]
+    simp only [hhdr, reduceIte]
+    match pb.auth with
+    | none =>
+      simp only [core.option.Option.as_ref, core.option.Option.ok_or,
+        core.result.Result.Insts.CoreOpsTry.branch,
+        core.result.Result.Insts.CoreOpsTryTraitFromResidualResultInfallible.from_residual,
+        core.convert.FromSame.from, bind_tc_ok, WP.spec_ok]
+    | some a' =>
+      simp only [core.option.Option.as_ref, core.option.Option.ok_or,
+        core.result.Result.Insts.CoreOpsTry.branch, bind_tc_ok]
+      step*
+      simp only [← a_post1, ← a_post2]
+  · rw [if_neg (by scalar_tac : ¬alloc.vec.Vec.len pb.hdr = 64#usize)]
+    simp [hhdr, WP.spec_ok]
+
+end spqr.v1.unchunked.send_ct.serialize.HeaderReceived


### PR DESCRIPTION
Closes #394, closes #396, closes #398, closes #400.

Adds spec theorems for the four remaining `from_pb` conversions in `v1/unchunked/send_ct/serialize.rs`, completing the send_ct serialize series started in #401:

| File | Issue | Length checks |
|---|---|---|
| `HeaderReceived/FromPb.lean` | #394 | `hdr = 64` |
| `Ct1Sent/FromPb.lean` | #396 | `hdr = 64`, `es = 2080`, `ct1 = 960` |
| `Ct1SentEkReceived/FromPb.lean` | #398 | `es = 2080`, `ct1 = 960`, `ek = 1152` |
| `Ct2Sent/FromPb.lean` | #400 | none |