### PR TITLE
Unify the two `.map(...).collect()` bridges into one named assumption

### DIFF
--- a/Spqr/Specs/Aeneas/MapCollectBridge.lean
+++ b/Spqr/Specs/Aeneas/MapCollectBridge.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE-APACHE.
-Authors: The Beneficial AI Foundation
+Authors: Lacramioara Astefanoaei
 -/
 import SrcTranslated.Funs
 import Spqr.Specs.Encoding.Polynomial.ConstPolysToPolys.MapCollect

--- a/Spqr/Specs/Aeneas/MapCollectBridge.lean
+++ b/Spqr/Specs/Aeneas/MapCollectBridge.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: The Beneficial AI Foundation
+-/
+import SrcTranslated.Funs
+import Spqr.Specs.Encoding.Polynomial.ConstPolysToPolys.MapCollect
+
+/-! # The single assumed bridge for `.map(...).collect()`
+
+Aeneas mis-translates the `Iterator` impl for `Map<I, F>`
+([aeneas#1043](https://github.com/AeneasVerif/aeneas/issues/1043)): it emits `map :=` and
+`collect :=` fields that do not exist in `core.iter.traits.iterator.Iterator`, and omits
+required ones. `aeneas-config.yml` works around this by deleting the bogus fields and
+replacing the body of `next` with `sorry`, which lands at `SrcTranslated/Funs.lean`:
+
+```
+impl_def core.iter.adapters.map.Map.Insts.CoreIterTraitsIteratorIterator ... := {
+  next := sorry -- See https://github.com/AeneasVerif/aeneas/issues/1043
+  ...
+}
+```
+
+Every generated `.map(...).collect()` call site therefore collects through an instance whose
+`next` is `sorryAx`. The intended semantics is supplied by hand in
+`SrcTranslated/FunsExternal.lean` via `mapIteratorTransformer`. `collect_default_bridge`
+below identifies the two.
+
+**This lemma is an assumption, not an unfinished proof.** Its left-hand side mentions
+`sorryAx`, which is opaque, so the statement is neither provable nor refutable — it is
+independent, and assuming it is consistent. What it buys is that the trust surface for
+*every* `.map(...).collect()` in the project is this one named statement, rather than one
+ad-hoc lemma per call site.
+
+It can only be discharged by making the model complete: either upstream fixes aeneas#1043,
+or the tweak is changed to emit a faithful `next`. See
+https://github.com/Beneficial-AI-Foundation/SparsePostQuantumRatchet-verify/issues/409.
+-/
+
+open Aeneas Aeneas.Std Result
+
+namespace Spqr.Aeneas
+
+/-- Collecting through the generated `Map` iterator instance agrees with collecting through
+the hand-written `mapIteratorTransformer` semantics.
+
+Keep `_hF`. No proof step uses it, because there is no proof, but it is still part of the
+statement. Deleting it would not simplify anything; it would strengthen the claim to cover
+closures with mutable state, and that stronger claim is false. `mapIteratorTransformer`
+freezes `map.f` and throws away the closure state `call_mut` returns, while a faithful
+`Map::next` threads it. Since `sorryAx` on the left proves either version, nothing would
+flag the change. Both call sites have `F = Unit`.
+
+Blocked on https://github.com/AeneasVerif/aeneas/issues/1043. -/
+theorem collect_default_bridge
+    {B I F B1 Clause0_Item : Type}
+    (_hF : Subsingleton F)
+    (iterInst : core.iter.traits.iterator.Iterator I Clause0_Item)
+    (fnMutInst : core.ops.function.FnMut F Clause0_Item B)
+    (fromIterInst : core.iter.traits.collect.FromIterator B1 B)
+    (m : core.iter.adapters.map.Map I F) :
+    core.iter.traits.iterator.Iterator.collect.default
+        (spqr.core.iter.adapters.map.Map.Insts.CoreIterTraitsIteratorIterator
+          iterInst fnMutInst)
+        fromIterInst m =
+      fromIterInst.from_iter
+        (core.iter.traits.collect.IntoIterator.Blanket
+          (core.iter.adapters.map.mapIteratorTransformer m iterInst fnMutInst))
+        m.iter := by
+  sorry -- Blocked on https://github.com/AeneasVerif/aeneas/issues/1043
+
+end Spqr.Aeneas

--- a/Spqr/Specs/Encoding/Polynomial/ConstPolysToPolys.lean
+++ b/Spqr/Specs/Encoding/Polynomial/ConstPolysToPolys.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE-APACHE.
-Authors: Hoang Le Truong
+Authors: Hoang Le Truong, Lacramioara Astefanoaei
 -/
 import Spqr.Specs.Aeneas.SliceIter
 import Spqr.Specs.Aeneas.MapCollectBridge

--- a/Spqr/Specs/Encoding/Polynomial/ConstPolysToPolys.lean
+++ b/Spqr/Specs/Encoding/Polynomial/ConstPolysToPolys.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE-APACHE.
 Authors: Hoang Le Truong
 -/
 import Spqr.Specs.Aeneas.SliceIter
+import Spqr.Specs.Aeneas.MapCollectBridge
 import Spqr.Specs.Encoding.Polynomial.ConstPolysToPolys.SliceIterMapCollect
 
 /-!
@@ -21,23 +22,6 @@ into the `Vec<Poly>` expected by `Poly.lagrange_sum`.
 open Aeneas Aeneas.Std Result
 
 namespace spqr.encoding.polynomial
-
-/-- Bridge between the Aeneas-generated `collect.default` (with `Map.Insts` whose
-`next := sorry`, see https://github.com/AeneasVerif/aeneas/issues/1043) and the
-external `Map.Insts.collect` (with proper `mapIteratorTransformer`). -/
-private theorem collect_default_bridge {N : Usize}
-    (m : core.iter.adapters.map.Map (core.slice.iter.Iter (PolyConst N))
-      (const_polys_to_polys.closure N)) :
-    core.iter.traits.iterator.Iterator.collect.default
-      (core.iter.adapters.map.Map.Insts.CoreIterTraitsIteratorIterator
-        (core.iter.traits.iterator.IteratorSliceIter (PolyConst N))
-        (const_polys_to_polys.closure.Insts.CoreOpsFunctionFnMutTupleSharedPolyConstPoly N))
-      (core.iter.traits.collect.FromIteratorVec Poly) m =
-    core.iter.adapters.map.Map.Insts.CoreIterTraitsIteratorIterator.collect
-      (core.iter.traits.iterator.IteratorSliceIter (PolyConst N))
-      (const_polys_to_polys.closure.Insts.CoreOpsFunctionFnMutTupleSharedPolyConstPoly N)
-      (core.iter.traits.collect.FromIteratorVec Poly) m := by
-  sorry -- Blocked on https://github.com/AeneasVerif/aeneas/issues/1043
 
 /--
 **Spec theorem for `encoding.polynomial.const_polys_to_polys`**:
@@ -57,7 +41,10 @@ theorem const_polys_to_polys_spec {N : Usize} (cps : Array (PolyConst N) N) :
           result[j].toGF216Poly = listToGF216Poly cps[j].coefficients) ⦄ := by
   unfold const_polys_to_polys
   step*
-  rw [collect_default_bridge]
+  -- Cross from the generated instance (whose `next` is `sorry`, aeneas#1043) to the
+  -- hand-written `mapIteratorTransformer` semantics, then fold back up into `collect`.
+  rw [Spqr.Aeneas.collect_default_bridge (inferInstanceAs (Subsingleton Unit)) _ _ _ m,
+    ← core.iter.adapters.map.Map.Insts.CoreIterTraitsIteratorIterator.collect_spec]
   apply WP.spec_mono
     (core.iter.adapters.map.Map.Insts.CoreIterTraitsIteratorIterator.collect_const_polys_spec m)
   intro result ⟨h_len, h_elts⟩

--- a/Spqr/Specs/Encoding/Polynomial/PolyEncoder/PointAt.lean
+++ b/Spqr/Specs/Encoding/Polynomial/PolyEncoder/PointAt.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE-APACHE.
-Authors: Hoang Le Truong
+Authors: Hoang Le Truong, Lacramioara Astefanoaei
 -/
 import Spqr.Specs.Encoding.Polynomial.NUM_POLYS
 import Spqr.Specs.Encoding.Polynomial.Poly.ComputeAt

--- a/Spqr/Specs/Encoding/Polynomial/PolyEncoder/PointAt.lean
+++ b/Spqr/Specs/Encoding/Polynomial/PolyEncoder/PointAt.lean
@@ -9,6 +9,7 @@ import Spqr.Math.Poly.Lagrange.CompletePoints
 import Spqr.Specs.Encoding.Polynomial.Poly.FromCompletePoints
 import Spqr.Specs.Encoding.Polynomial.PolyEncoder.PointAt.CallOnce
 import Spqr.Specs.Aeneas.MapIteratorTransformerNext
+import Spqr.Specs.Aeneas.MapCollectBridge
 import Spqr.Specs.Encoding.Polynomial.PolyEncoder.PointAt.SliceIterEnumMapCollect
 
 
@@ -250,30 +251,7 @@ private lemma array_set_restore_set_getElem!
   have : i.val < arr.val.length := by rw [arr.property]; exact hi
   grind
 
-/-! ## Axiom for the map+collect pipeline -/
-
-/-- `Iterator.collect.default` on a `Map (Enumerate (Iter GF16)) closure_1` equals
-`FromIteratorVec.from_iter` with `mapIteratorTransformer`, using `m.iter` as initial state.
-
-This bridges generated Aeneas code with the hand-verified `from_iter_point_at_spec`. -/
-private theorem map_collect_eq_point_at
-    (m : PointAtMapT) :
-    core.iter.traits.iterator.Iterator.collect.default
-        (core.iter.adapters.map.Map.Insts.CoreIterTraitsIteratorIterator
-          (core.iter.traits.iterator.IteratorEnumerate
-            (core.iter.traits.iterator.IteratorSliceIter GF16))
-          Insts.CoreOpsFunctionFnMutTuplePairUsizeSharedGF16Pt)
-        (core.iter.traits.collect.FromIteratorVec Pt)
-        m
-    = alloc.vec.FromIteratorVec.from_iter
-        (core.iter.traits.collect.IntoIterator.Blanket
-          (core.iter.adapters.map.mapIteratorTransformer
-            ({ iter := m.iter, f := () } : PointAtMapT)
-            (core.iter.traits.iterator.IteratorEnumerate
-              (core.iter.traits.iterator.IteratorSliceIter GF16))
-            Insts.CoreOpsFunctionFnMutTuplePairUsizeSharedGF16Pt))
-        m.iter := by
-  sorry
+/-! ## Bridge for the map+collect pipeline -/
 
 /-! ## Spec theorem for the point_at loop body -/
 
@@ -346,7 +324,13 @@ theorem body_spec
       List.Inhabited_getElem_eq_getElem! pts.val iter.start.val h_pts_lt
     simp only [alloc.vec.Vec.len]
     -- Apply the collect axiom, substitute m.iter via m_post, normalize with h_eq
-    simp only [map_collect_eq_point_at, m_post, h_eq]; clear h_eq h_pts_lt
+    have h_bridge := Spqr.Aeneas.collect_default_bridge
+      (inferInstanceAs (Subsingleton Unit))
+      (core.iter.traits.iterator.IteratorEnumerate
+        (core.iter.traits.iterator.IteratorSliceIter GF16))
+      Insts.CoreOpsFunctionFnMutTuplePairUsizeSharedGF16Pt
+      (core.iter.traits.collect.FromIteratorVec Pt) m
+    simp only [h_bridge, m_post, h_eq]; clear h_eq h_pts_lt
     apply WP.spec_bind (from_iter_point_at_spec
       (alloc.vec.Vec.deref ((pts.val[iter.start.val]!).value)) h_len_le)
     intro pt_vec ⟨h_pt_len, h_pt_elts⟩


### PR DESCRIPTION
`ConstPolysToPolys.collect_default_bridge` and `PolyEncoder.point_at_loop.map_collect_eq_point_at` were two separate `sorry`s asserting the same thing at different type arguments: that collecting through the Aeneas-generated `Map` iterator instance agrees with the hand-written `mapIteratorTransformer` semantics. The generated instance is generic in `I`/`F`/`B`, so one lemma covers both.

Both are now proved corollaries of a single `Spqr.Aeneas.collect_default_bridge` in the new `Spqr/Specs/Aeneas/MapCollectBridge.lean`.

The reason to do so is to minimise the trust surface which was growing one `sorry` per `.map(...).collect()` call site, and the documentation quality was drifting: `collect_default_bridge` carried an inline link to [aeneas#1043](https://github.com/AeneasVerif/aeneas/issues/1043), the newer `map_collect_eq_point_at` was bare. `scripts/check-lint.sh` filters `declaration uses 'sorry'` out of the warning gate, so nothing flagged the second one.

There is now one place to attach the link, one docstring explaining that this is an *assumption* rather than an unfinished proof, and one thing to delete when aeneas#1043 is fixed.

The PR does not discharge the assumption. Still blocked on aeneas#1043. It replaces 2 sorries by 1.

Closes #409. 

Made with [Cursor](https://cursor.com)
