### PR TITLE
Update mechanism for installing charon/aeneas

### DIFF
--- a/.github/workflows/aeneas.yml
+++ b/.github/workflows/aeneas.yml
@@ -1,4 +1,4 @@
-# Confirm Aeneas extraction succeeds 
+# Confirm Aeneas extraction succeeds
 
 name: Aeneas extraction
 on:
@@ -15,7 +15,7 @@ on:
   # as "not passed").  Restricting `push` to main avoids duplicate runs on
   # PR branches.
   # See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
-  pull_request: 
+  pull_request:
     branches: [ '**' ]
   workflow_dispatch:
 
@@ -27,14 +27,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential git curl opam pkg-config libgmp-dev protobuf-compiler
-
-      - name: Initialize opam
-        run: opam init --disable-sandboxing -y -a
+          sudo apt-get install -y build-essential git curl pkg-config libgmp-dev protobuf-compiler
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -46,14 +42,6 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache OCaml environment
-        uses: actions/cache@v5
-        with:
-          path: ~/.opam
-          key: ${{ runner.os }}-opam-v1
-          restore-keys: |
-            ${{ runner.os }}-opam-
 
       - name: Cache Rust build artifacts
         uses: actions/cache@v5
@@ -67,7 +55,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      - name: Cache Aeneas build
+      - name: Cache Aeneas release bundle
         uses: actions/cache@v5
         with:
           path: .aeneas

--- a/aeneas-config.yml
+++ b/aeneas-config.yml
@@ -1,7 +1,7 @@
 # Aeneas extraction configuration
 
 aeneas:
-  commit: "6e167c9b" # pinned commit hash
+  tag: "nightly-2026.07.25-6e167c9"
   repo: "https://github.com/AeneasVerif/aeneas.git"
 
 # Upstream Rust crate we are verifying

--- a/doc/aeneas.md
+++ b/doc/aeneas.md
@@ -1,27 +1,28 @@
 # Updating Aeneas
 
-This repo depends on Aeneas in two places that must stay pinned to the same commit:
+This repo consumes Aeneas from a single **GitHub release tag**, used in two places that must stay
+in sync:
 
-1. `aeneas-config.yml` (`aeneas.commit`): the commit used to build the Charon + Aeneas
-   binaries (`npm run aeneas-install` clones both here and builds them).
-   These binaries produce the extraction (`SrcTranslated/*`, `translation.json`).
-2. `lakefile.toml` (`[[require]] name = "aeneas"`, `rev`): the Aeneas Lean library the
-   extracted code and our specs are checked against.
+1. `aeneas-config.yml` (`aeneas.tag`): the release whose Charon + Aeneas **binaries** are downloaded
+   by `npm run aeneas-install` into `.aeneas/`. These produce the extraction (`SrcTranslated/*`,
+   `translation.json`).
+2. `lakefile.toml` (`[[require]] name = "aeneas"`, `rev`): the Aeneas **Lean library** our specs are
+   checked against.
 
 ## Procedure
 
 ```bash
-# 1. Find the latest main commit.
-git ls-remote https://github.com/AeneasVerif/aeneas.git refs/heads/main
+# 1. Pick a release.
+gh release list -R AeneasVerif/aeneas
 
-# 2. Set both pins to that commit (short or full SHA):
-#      - aeneas-config.yml :  aeneas.commit: "<sha>"
-#      - lakefile.toml     :  rev = "<sha>"   (under [[require]] name = "aeneas")
+# 2. Set the same tag in both places:
+#      - aeneas-config.yml :  aeneas.tag: "<tag>"
+#      - lakefile.toml     :  rev = "<tag>" (under [[require]] name = "aeneas")
 
 # 3. Refresh `lake-manifest.json`.
 lake update aeneas
 
-# 4. Rebuild the Charon + Aeneas binaries at the new commit.
+# 4. Download the Charon + Aeneas binaries for the new tag.
 npm run aeneas-install
 
 # 5. Re-extract: Charon -> Aeneas -> tweaks.
@@ -30,3 +31,20 @@ npm run aeneas-extract
 # 6. Typecheck the project and fix any breakage from the update.
 lake build
 ```
+
+Step 4 also installs the Rust nightly that the bundled `charon-driver` needs (named in the
+bundle's `rust-toolchain`), and syncs `lean-toolchain` if the release uses a different one.
+
+## Checking the olean cache is actually used
+
+If Lake is compiling `Aeneas.*` from source, the `rev` is not resolving to a release:
+
+```bash
+rm -rf .lake/packages/aeneas
+lake build 2>&1 | tee /tmp/build.log
+grep -ci "Building Aeneas" /tmp/build.log   # expect 0
+```
+
+## Platform support
+
+Release binaries exist only for linux x86_64, linux aarch64, and macOS aarch64.

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -8,7 +8,7 @@
    "rev": "6e167c9b63a4dafd66d0e0edd9d94669f957ff7b",
    "name": "aeneas",
    "manifestFile": "lake-manifest.json",
-   "inputRev": "6e167c9b",
+   "inputRev": "nightly-2026.07.25-6e167c9",
    "inherited": false,
    "configFile": "lakefile.lean"},
   {"url": "https://github.com/leanprover-community/mathlib4.git",

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -17,7 +17,7 @@ maxRecDepth = 10000
 name = "aeneas"
 git = "https://github.com/AeneasVerif/aeneas.git"
 subDir = "backends/lean"
-rev = "6e167c9b"
+rev = "nightly-2026.07.25-6e167c9"
 
 # Slightly modified copy of Mathlib's header linter (`linter.style.headerAlt`).  Pending the upstream
 # PR which adds a config option and then this will be removed from here.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,7 +2,7 @@
 
 ## Commands
 
-- **`npm run aeneas-install`** — Clone and build aeneas + charon from source. Skips rebuild if the installed version matches the pinned commit.
+- **`npm run aeneas-install`** — Download the aeneas + charon binaries from the pinned GitHub release into `.aeneas/`, and install the Rust nightly `charon-driver` needs. Skips the download if the installed version already matches the pinned tag.
 - **`npm run aeneas-extract`** — Run the extraction pipeline: charon (Rust → LLBC) → aeneas (LLBC → Lean) → post-extraction tweaks.
 - **`npm run src-diff`** — Generate `src-modifications.diff` comparing local `src/` against the pinned upstream commit.
 
@@ -12,7 +12,7 @@ All extraction options live in `aeneas-config.yml` at the project root.
 
 ## Updating the aeneas version
 
-The aeneas commit is pinned in two places that must be kept in sync:
+The aeneas **release tag** is pinned in two places that must be kept in sync:
 
-1. `aeneas-config.yml` — `aeneas.commit` (used by the install/extract scripts)
+1. `aeneas-config.yml` — `aeneas.tag` (used by the install/extract scripts for the binaries)
 2. `lakefile.toml` — `rev` in the aeneas `[[require]]` block (used by Lake for the Lean backend dependency)

--- a/scripts/aeneas-install.ts
+++ b/scripts/aeneas-install.ts
@@ -1,15 +1,13 @@
 /**
- * Clone and build aeneas + charon from source.
+ * Download and install the charon + aeneas binaries from a GitHub release.
  *
  * Steps:
- * 1. Check dependencies (git, opam, make, rustup)
- * 2. Setup OCaml 5.2.0 switch + deps
- * 3. Clone/update aeneas repo at pinned commit
- * 4. Setup rust nightly toolchain for charon
- * 5. Build charon (make setup-charon)
- * 6. Build aeneas (make)
+ * 1. Check dependencies (curl, tar, rustup)
+ * 2. Download the release bundle for this platform
+ * 3. Extract it into .aeneas/
+ * 4. Install the Rust nightly that the bundled charon-driver requires
  *
- * Skips rebuild if the installed aeneas version matches the pinned commit.
+ * Skips the download if the installed aeneas already reports the pinned release tag.
  */
 
 import fs from "node:fs";
@@ -17,7 +15,7 @@ import path from "node:path";
 import chalk from "chalk";
 import ora from "ora";
 import { loadConfig } from "./lib/config.js";
-import { run, runStreaming } from "./lib/shell.js";
+import { run } from "./lib/shell.js";
 import { findBinary } from "./lib/paths.js";
 import { syncLeanToolchain } from "./lib/lean-toolchain.js";
 
@@ -27,36 +25,49 @@ function getAeneasDir(root: string): string {
   return path.join(root, ".aeneas");
 }
 
-function getRepoDir(root: string): string {
-  return path.join(getAeneasDir(root), "aeneas");
+// ── Release assets ────────────────────────────────────────────────────
+
+/**
+ * The release asset for the current platform.
+ */
+function getAssetName(): string {
+  const key = `${process.platform}-${process.arch}`;
+  const assets: Record<string, string> = {
+    "linux-x64": "aeneas-linux-x86_64.tar.gz",
+    "linux-arm64": "aeneas-linux-aarch64.tar.gz",
+    "darwin-arm64": "aeneas-macos-aarch64.tar.gz",
+  };
+
+  const asset = assets[key];
+  if (!asset) {
+    throw new Error(
+      `No aeneas release build for ${key}. Supported: ${Object.keys(assets).join(", ")}. ` +
+        `Build aeneas from source and place the 'aeneas', 'charon' and 'charon-driver' ` +
+        `binaries plus 'backends/' in .aeneas/`,
+    );
+  }
+  return asset;
+}
+
+function getAssetUrl(repo: string, tag: string, asset: string): string {
+  // https://github.com/AeneasVerif/aeneas.git -> https://github.com/AeneasVerif/aeneas
+  const base = repo.replace(/\.git$/, "");
+  return `${base}/releases/download/${tag}/${asset}`;
 }
 
 // ── Version check ─────────────────────────────────────────────────────
 
 /**
- * Check if the currently installed aeneas matches the pinned commit.
- * Uses `aeneas -version` if available, falls back to git rev-parse.
+ * The release tag reported by the installed aeneas, or null if it is absent or unreadable.
+ * A release build prints `aeneas <tag>`.
  */
-async function getInstalledVersion(root: string): Promise<string | null> {
+async function getInstalledTag(root: string): Promise<string | null> {
   const aeneasBin = findBinary("aeneas", root);
   if (!aeneasBin) return null;
 
-  // Try aeneas -version first (available in recent builds)
   try {
     const output = await run(aeneasBin, ["-version"], { silent: true });
-    // Expected to contain a commit hash
-    const match = output.match(/[0-9a-f]{8,40}/);
-    if (match) return match[0];
-  } catch {
-    // -version not supported in this build, fall through
-  }
-
-  // Fallback: check git commit in the repo dir
-  const repoDir = getRepoDir(root);
-  if (!fs.existsSync(repoDir)) return null;
-  try {
-    const output = await run("git", ["rev-parse", "HEAD"], { cwd: repoDir, silent: true });
-    return output.trim();
+    return output.trim().replace(/^aeneas\s+/, "") || null;
   } catch {
     return null;
   }
@@ -66,7 +77,7 @@ async function getInstalledVersion(root: string): Promise<string | null> {
 
 async function checkDependencies(): Promise<void> {
   const spinner = ora("Checking dependencies...").start();
-  const deps = ["git", "opam", "make", "rustup"];
+  const deps = ["curl", "tar", "rustup"];
   const missing: string[] = [];
 
   for (const dep of deps) {
@@ -84,47 +95,6 @@ async function checkDependencies(): Promise<void> {
   spinner.succeed("Dependencies OK");
 }
 
-// ── OCaml setup ───────────────────────────────────────────────────────
-
-async function getOpamEnv(switchName: string): Promise<Record<string, string>> {
-  const output = await run("opam", ["env", `--switch=${switchName}`, "--set-switch"], {
-    silent: true,
-  });
-  const env: Record<string, string> = {};
-  for (const line of output.split("\n")) {
-    const match = line.match(/^(\w+)='([^']*)'; export \1;/);
-    if (match) {
-      env[match[1]] = match[2];
-    }
-  }
-  return env;
-}
-
-const OCAML_DEPS = [
-  "ppx_deriving", "ppx_deriving_yojson", "visitors", "easy_logging", "zarith", "yojson",
-  "core_unix", "odoc", "ocamlgraph", "menhir", "ocamlformat",
-  "unionFind", "domainslib", "progress",
-];
-
-async function setupOcaml(): Promise<Record<string, string>> {
-  const switchName = "5.2.0";
-  const switches = await run("opam", ["switch", "list", "--short"], { silent: true });
-  const exists = switches.split("\n").some((s) => s.trim() === switchName);
-
-  if (!exists) {
-    console.log("  Creating OCaml 5.2.0 switch...");
-    await runStreaming("opam", ["switch", "create", switchName]);
-  }
-
-  const env = await getOpamEnv(switchName);
-
-  console.log("  Installing OCaml dependencies...");
-  await run("opam", ["update"], { silent: true, env });
-  await run("opam", ["install", "-y", ...OCAML_DEPS], { silent: true, env });
-
-  return env;
-}
-
 // ── Rust toolchain ────────────────────────────────────────────────────
 
 function parseToolchainChannel(filePath: string): string | null {
@@ -134,66 +104,41 @@ function parseToolchainChannel(filePath: string): string | null {
   return match ? match[1] : null;
 }
 
-async function setupRustToolchain(repoDir: string): Promise<void> {
-  const charonDir = path.join(repoDir, "charon");
-  const toolchain =
-    parseToolchainChannel(path.join(charonDir, "charon", "rust-toolchain.toml")) ??
-    parseToolchainChannel(path.join(charonDir, "charon", "rust-toolchain")) ??
-    parseToolchainChannel(path.join(charonDir, "rust-toolchain.toml")) ??
-    parseToolchainChannel(path.join(charonDir, "rust-toolchain")) ??
-    "nightly";
+/**
+ * The bundled charon-driver is a rustc driver built against a specific nightly, so that exact
+ * toolchain must be installed locally with `rustc-dev`. The bundle ships the `rust-toolchain`
+ * file naming it.
+ */
+async function setupRustToolchain(aeneasDir: string): Promise<void> {
+  const toolchain = parseToolchainChannel(path.join(aeneasDir, "rust-toolchain")) ?? "nightly";
 
   const spinner = ora(`Installing Rust ${toolchain}...`).start();
   await run("rustup", ["toolchain", "install", toolchain], { silent: true });
-  await run("rustup", ["component", "add", "--toolchain", toolchain, "rustfmt", "rustc-dev"], { silent: true });
+  await run("rustup", ["component", "add", "--toolchain", toolchain, "rustfmt", "rustc-dev"], {
+    silent: true,
+  });
   spinner.succeed(`Rust ${toolchain} ready`);
 }
 
-// ── Git operations ────────────────────────────────────────────────────
+// ── Download and extract ──────────────────────────────────────────────
 
-async function setupRepo(repo: string, repoDir: string, commit: string): Promise<void> {
-  if (!fs.existsSync(repoDir)) {
-    const spinner = ora(`Cloning ${repo}...`).start();
-    await run("git", ["clone", repo, repoDir], { silent: true });
-    spinner.succeed(`Cloned ${repo}`);
-  } else {
-    // Make sure `origin` points at the configured repo before fetching.
-    let originUrl: string | null = null;
-    try {
-      const out = await run("git", ["remote", "get-url", "origin"], { cwd: repoDir, silent: true });
-      originUrl = out.trim();
-    } catch {
-      // no `origin` remote configured
-    }
-    if (originUrl !== repo) {
-      const action = originUrl === null ? "add" : "set-url";
-      const spinner = ora(
-        originUrl === null ? `Adding 'origin' → ${repo}...` : `Repointing 'origin' ${originUrl} → ${repo}...`,
-      ).start();
-      await run("git", ["remote", action, "origin", repo], { cwd: repoDir, silent: true });
-      spinner.succeed(`'origin' set to ${repo}`);
-    }
-  }
+async function downloadAndExtract(url: string, aeneasDir: string): Promise<void> {
+  // Wipe first: the previous build-from-source layout had .aeneas/aeneas as a directory,
+  // whereas the bundle extracts it as a file.
+  fs.rmSync(aeneasDir, { recursive: true, force: true });
+  fs.mkdirSync(aeneasDir, { recursive: true });
 
-  // Fetch from `origin` and check out the pin.
-  const spinner = ora(`Fetching Aeneas ${commit}...`).start();
-  await run("git", ["fetch", "--force", "--tags", "origin"], { cwd: repoDir, silent: true });
-  await run("git", ["checkout", commit], { cwd: repoDir, silent: true });
-  spinner.succeed(`Aeneas at ${commit}`);
-}
+  const archive = path.join(aeneasDir, "bundle.tar.gz");
 
-// ── Build ─────────────────────────────────────────────────────────────
+  console.log(chalk.dim(`  ${url}`));
+  // -sS rather than a progress bar: the carriage returns flood CI logs.
+  const spinner = ora("Downloading...").start();
+  await run("curl", ["-fL", "-sS", "-o", archive, url], { silent: true });
 
-async function buildCharon(repoDir: string, env: Record<string, string>): Promise<void> {
-  const spinner = ora("Building Charon...").start();
-  await runStreaming("make", ["setup-charon"], { cwd: repoDir, env });
-  spinner.succeed("Charon built");
-}
-
-async function buildAeneas(repoDir: string, env: Record<string, string>): Promise<void> {
-  const spinner = ora("Building Aeneas...").start();
-  await runStreaming("make", [], { cwd: repoDir, env });
-  spinner.succeed("Aeneas built");
+  spinner.text = "Extracting...";
+  await run("tar", ["-xzf", archive, "-C", aeneasDir], { silent: true });
+  fs.rmSync(archive, { force: true });
+  spinner.succeed("Downloaded and extracted");
 }
 
 // ── Main ──────────────────────────────────────────────────────────────
@@ -202,42 +147,40 @@ async function main(): Promise<void> {
   console.log(chalk.bold("\nAeneas Install\n"));
 
   const { config, root } = loadConfig();
-  const commit = config.aeneas.commit;
-  const repoDir = getRepoDir(root);
+  const tag = config.aeneas.tag;
+  const aeneasDir = getAeneasDir(root);
 
-  // Check if already installed at correct version
-  const installed = await getInstalledVersion(root);
-  if (installed && installed.startsWith(commit)) {
-    const charonBin = findBinary("charon", root);
-    const aeneasBin = findBinary("aeneas", root);
-    if (charonBin && aeneasBin) {
-      console.log(chalk.green(`Already up to date (${commit}). Skipping.`));
-      return;
-    }
+  // Check if already installed at the correct release
+  const installed = await getInstalledTag(root);
+  if (installed === tag && findBinary("charon", root)) {
+    console.log(chalk.green(`Already up to date (${tag}). Skipping.`));
+    return;
   }
 
   await checkDependencies();
 
-  console.log(chalk.bold("\nSetting up OCaml..."));
-  const opamEnv = await setupOcaml();
-  console.log(chalk.green("  OCaml environment ready\n"));
+  const asset = getAssetName();
+  const url = getAssetUrl(config.aeneas.repo, tag, asset);
 
-  await setupRepo(config.aeneas.repo, repoDir, commit);
-  await setupRustToolchain(repoDir);
+  console.log(chalk.bold(`\nDownloading ${tag} (${asset})...`));
+  await downloadAndExtract(url, aeneasDir);
 
-  console.log();
-  await buildCharon(repoDir, opamEnv);
-  await buildAeneas(repoDir, opamEnv);
+  await setupRustToolchain(aeneasDir);
 
-  // Verify binaries exist
+  // Verify binaries exist and report the expected release
   const charonBin = findBinary("charon", root);
   const aeneasBin = findBinary("aeneas", root);
 
   if (!charonBin || !aeneasBin) {
-    throw new Error("Build completed but binaries not found at expected paths");
+    throw new Error("Download completed but binaries not found at expected paths");
   }
 
-  console.log(chalk.green("\nBuild complete!"));
+  const actual = await getInstalledTag(root);
+  if (actual !== tag) {
+    throw new Error(`Version mismatch: expected '${tag}', got '${actual}'`);
+  }
+
+  console.log(chalk.green("\nInstall complete!"));
   console.log(`  Charon: ${charonBin}`);
   console.log(`  Aeneas: ${aeneasBin}`);
 

--- a/scripts/lib/config.ts
+++ b/scripts/lib/config.ts
@@ -10,7 +10,7 @@ export interface Substitution {
 
 export interface AeneasConfig {
   aeneas: {
-    commit: string;
+    tag: string;
     repo: string;
   };
   upstream: {
@@ -81,7 +81,7 @@ export function loadConfig(root?: string): { config: AeneasConfig; root: string 
   const config = raw as unknown as AeneasConfig;
 
   // Validate required fields
-  if (!config.aeneas?.commit) throw new Error("Missing required field: aeneas.commit");
+  if (!config.aeneas?.tag) throw new Error("Missing required field: aeneas.tag");
   if (!config.aeneas?.repo) throw new Error("Missing required field: aeneas.repo");
   if (!config.crate?.dir) throw new Error("Missing required field: crate.dir");
 

--- a/scripts/lib/lean-toolchain.ts
+++ b/scripts/lib/lean-toolchain.ts
@@ -3,12 +3,12 @@ import path from "node:path";
 import chalk from "chalk";
 
 /**
- * Sync the project's lean-toolchain file with the one from the aeneas repo.
+ * Sync the project's lean-toolchain file with the one shipped in the aeneas release bundle.
  * No-op if either file is missing.
  */
 export function syncLeanToolchain(root: string): void {
   const projectToolchain = path.join(root, "lean-toolchain");
-  const aeneasToolchain = path.join(root, ".aeneas", "aeneas", "backends", "lean", "lean-toolchain");
+  const aeneasToolchain = path.join(root, ".aeneas", "backends", "lean", "lean-toolchain");
 
   if (!fs.existsSync(aeneasToolchain) || !fs.existsSync(projectToolchain)) return;
 

--- a/scripts/lib/paths.ts
+++ b/scripts/lib/paths.ts
@@ -1,31 +1,17 @@
 import path from "node:path";
 import fs from "node:fs";
-import { execSync } from "node:child_process";
 
 /**
- * Resolve a binary from .aeneas/aeneas/ (build-from-source layout), falling back to PATH.
+ * Resolve a binary from the extracted aeneas release bundle.
  *
- * Build layout:
- *   .aeneas/aeneas/bin/aeneas
- *   .aeneas/aeneas/charon/bin/charon
+ * Bundle layout:
+ *   .aeneas/aeneas
+ *   .aeneas/charon
+ *   .aeneas/charon-driver
+ *   .aeneas/rust-toolchain
+ *   .aeneas/backends/...
  */
 export function findBinary(name: "charon" | "aeneas", root: string): string | null {
-  const repoDir = path.join(root, ".aeneas", "aeneas");
-
-  const localPaths =
-    name === "charon"
-      ? [path.join(repoDir, "charon", "bin", "charon")]
-      : [path.join(repoDir, "bin", "aeneas")];
-
-  for (const p of localPaths) {
-    if (fs.existsSync(p)) return p;
-  }
-
-  // Fall back to PATH
-  try {
-    const result = execSync(`which ${name}`, { encoding: "utf-8" }).trim();
-    return result || null;
-  } catch {
-    return null;
-  }
+  const p = path.join(root, ".aeneas", name);
+  return fs.existsSync(p) ? p : null;
 }

--- a/translation.json
+++ b/translation.json
@@ -1,5 +1,5 @@
 {
-  "aeneas_version": "6e167c9b",
+  "aeneas_version": "nightly-2026.07.25-6e167c9",
   "charon_version": "0.1.225",
   "crate": "spqr",
   "functions": [


### PR DESCRIPTION
This PR uses an updated mechanism for installing charon and aeneas: instead of building from source it downloads the github release artifact. This is quicker and uses much less storage locally. Moreover the lean project is set to use aeneas from the github release tag and so can automatically obtain cache from there rather than rebuilding aeneas.