### PR TITLE
Erasure Codes bridge

### DIFF
--- a/Protocols.lean
+++ b/Protocols.lean
@@ -1,0 +1,11 @@
+import Protocols.ErasureCode.Contract
+import Protocols.ErasureCode.Correct
+import Protocols.ErasureCode.Correctness.Decode
+import Protocols.ErasureCode.Correctness.Encode
+import Protocols.ErasureCode.Correctness.Maps
+import Protocols.ErasureCode.Correctness.Params
+import Protocols.ErasureCode.Model.Defs
+import Protocols.ErasureCode.Model.ReedSolomon.Construction
+import Protocols.ErasureCode.Model.ReedSolomon.Correctness
+import Protocols.ErasureCode.Model.SPQRReedSolomon.Construction
+import Protocols.ErasureCode.Model.SPQRReedSolomon.Correctness

--- a/Protocols/ErasureCode/Contract.lean
+++ b/Protocols/ErasureCode/Contract.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Alessandro D'Angelo
+-/
+import Protocols.ErasureCode.Correctness.Maps
+import SrcTranslated.FunsExternal
+import Spqr.Specs.Encoding.Polynomial.PolyDecoder.NewWithPolyCount
+
+/-! # Contract for the opaque polynomial decoder -/
+
+open Aeneas Aeneas.Std Result Polynomial
+open spqr encoding.polynomial
+open spqr.encoding.polynomial.PolyDecoder.Insts.SpqrEncodingDecoder
+
+namespace Protocols.ErasureCode
+
+/-- Points the decoder needs in store `j`. -/
+def neededPoints (pd : PolyDecoder) (j : Nat) : Nat :=
+  pd.pts_needed.val / 16 + if j < pd.pts_needed.val % 16 then 1 else 0
+
+/-- Strictly sorted by x, hence sorted and duplicate-free. -/
+def SortedStore (l : List Pt) : Prop :=
+  l.Pairwise (fun p q => p.x.value.val < q.x.value.val)
+
+/-- Every stored point lies on `P`. -/
+def StoreOn (l : List Pt) (P : Polynomial GF216) : Prop :=
+  ∀ p ∈ l, P.eval p.x.toGF216 = p.y.toGF216
+
+/-- Assumption about the shipped Rust `decoded_message` implementation: a short point store
+forces decoding to return `none`. The function is opaque to extraction and this assumption can
+become a theorem if that Rust function is refactored for extraction. -/
+@[step]
+axiom decoded_message_spec_short
+    (pd : PolyDecoder)
+    (h_short : ∃ j, j < 16 ∧ ((pd.pts[j]!).val).length < neededPoints pd j) :
+    spqr.encoding.polynomial.PolyDecoder.Insts.SpqrEncodingDecoder.decoded_message pd
+      ⦃ (r : Option (alloc.vec.Vec U8)) => r = none ⦄
+
+/-- Assumption about the shipped Rust `decoded_message` implementation: complete sorted point
+stores on low-degree polynomials serialize their evaluations. The function is opaque to
+extraction and this assumption can become a theorem if that Rust function is refactored for
+extraction. -/
+@[step]
+axiom decoded_message_spec_complete
+    (pd : PolyDecoder) (P : Nat → Polynomial GF216)
+    (h_flag : pd.is_complete = false)
+    (h_sorted : ∀ j, j < 16 → SortedStore (pd.pts[j]!).val)
+    (h_on : ∀ j, j < 16 → StoreOn (pd.pts[j]!).val (P j))
+    (h_deg : ∀ j, j < 16 → (P j).degree < (neededPoints pd j : WithBot ℕ))
+    (h_len : ∀ j, j < 16 → neededPoints pd j ≤ ((pd.pts[j]!).val).length) :
+    spqr.encoding.polynomial.PolyDecoder.Insts.SpqrEncodingDecoder.decoded_message pd
+      ⦃ (r : Option (alloc.vec.Vec U8)) =>
+      ∃ out, r = some out ∧ out.length = 2 * pd.pts_needed.val ∧
+        ∀ i, i < pd.pts_needed.val →
+          Nat.toGF216 (256 * (out.val[2 * i]!).val + (out.val[2 * i + 1]!).val)
+            = (P (i % 16)).eval ((i / 16 : ℕ).toGF216) ⦄
+
+end Protocols.ErasureCode

--- a/Protocols/ErasureCode/Contract.lean
+++ b/Protocols/ErasureCode/Contract.lean
@@ -7,7 +7,25 @@ import Protocols.ErasureCode.Correctness.Maps
 import SrcTranslated.FunsExternal
 import Spqr.Specs.Encoding.Polynomial.PolyDecoder.NewWithPolyCount
 
-/-! # Contract for the opaque polynomial decoder -/
+/-!
+# Contract for the opaque polynomial decoder
+
+The proof assumes the two contracts below for the shipped opaque `decoded_message` function. They
+cover point lookup, slicing, interpolation or direct evaluation, and byte serialization.
+
+The Rust Hax annotation on `Poly.lagrange_interpolate` limits input to 36 points. The proved Lean
+helper `spqr.encoding.polynomial.Poly.lagrange_interpolate_spec` requires only
+`pts.length + 1 ≤ Usize.max`. Its axiom closure contains the standard logical axioms and the
+pre-existing certificate
+`spqr.encoding.polynomial.Poly.lagrange_interpolate_complete._native.decide.ax_1`. That helper is
+supporting evidence for the contracts. It proves neither contract, and its certificate is outside
+the current closure of `concreteSpqrErasureCode_correct`.
+
+The short path returns before allocating an output byte vector. On the complete path, strict
+ordering of U16 x-values bounds each store by 65536 points. The sixteen per-store quotas therefore
+give `pts_needed ≤ 16 * 65536`, so the `2 * pts_needed` output fits the supported `usize` range.
+This source-level bound supports the assumptions; it is not a Lean proof.
+-/
 
 open Aeneas Aeneas.Std Result Polynomial
 open spqr encoding.polynomial
@@ -27,9 +45,9 @@ def SortedStore (l : List Pt) : Prop :=
 def StoreOn (l : List Pt) (P : Polynomial GF216) : Prop :=
   ∀ p ∈ l, P.eval p.x.toGF216 = p.y.toGF216
 
-/-- Assumption about the shipped Rust `decoded_message` implementation: a short point store
-forces decoding to return `none`. The function is opaque to extraction and this assumption can
-become a theorem if that Rust function is refactored for extraction. -/
+/-- Assume that the shipped opaque `decoded_message` returns `none` if any of its sixteen stores
+is below quota. No `is_complete` premise is needed because the implementation also returns `none`
+when that flag is set. -/
 @[step]
 axiom decoded_message_spec_short
     (pd : PolyDecoder)
@@ -37,10 +55,8 @@ axiom decoded_message_spec_short
     spqr.encoding.polynomial.PolyDecoder.Insts.SpqrEncodingDecoder.decoded_message pd
       ⦃ (r : Option (alloc.vec.Vec U8)) => r = none ⦄
 
-/-- Assumption about the shipped Rust `decoded_message` implementation: complete sorted point
-stores on low-degree polynomials serialize their evaluations. The function is opaque to
-extraction and this assumption can become a theorem if that Rust function is refactored for
-extraction. -/
+/-- Assume that, from `is_complete = false`, sufficiently long and strictly sorted stores whose
+points lie on polynomials below their per-store quotas serialize the requested evaluations. -/
 @[step]
 axiom decoded_message_spec_complete
     (pd : PolyDecoder) (P : Nat → Polynomial GF216)

--- a/Protocols/ErasureCode/Correct.lean
+++ b/Protocols/ErasureCode/Correct.lean
@@ -1,0 +1,56 @@
+/-
+Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Alessandro D'Angelo
+-/
+import Protocols.ErasureCode.Correctness.Decode
+
+/-! # Correctness of the concrete SPQR erasure code -/
+
+open ErasureCode.SPQRReedSolomon
+
+namespace Protocols.ErasureCode
+
+noncomputable def concreteSpqrErasureCode
+    (k : ℕ) (hk : k ≤ 2 ^ 16) (hk_pos : 0 < k) :
+    ErasureCode (Chunk GF16) where
+  N := 2 ^ 16
+  N_pos := by norm_num
+  nchunk := k
+  nchunk_pos := hk_pos
+  nchunk_le_N := hk
+  encode := encodeConcrete k hk
+  decode := decodeConcrete k hk
+
+theorem encodeChunks_toModel
+    (k : ℕ) (hk : k ≤ 2 ^ 16) (hk_pos : 0 < k)
+    (hk_tab : k ∈ ({1, 3, 5, 30, 34, 36} : Finset ℕ))
+    (M : Fin k → Chunk GF16) (I : Finset (Fin (2 ^ 16))) :
+    (concreteSpqrErasureCode k hk hk_pos).encodeChunks M I =
+      (modelEC k hk hk_pos).encodeChunks M I := by
+  classical
+  unfold ErasureCode.encodeChunks
+  congr 1
+  apply Function.Embedding.ext
+  intro i
+  change (i, encodeConcrete k hk M i) =
+    (i, (modelEC k hk hk_pos).encode M i)
+  exact Prod.ext rfl (encode_toModel k hk hk_pos hk_tab M i)
+
+theorem concreteSpqrErasureCode_correct
+    (k : ℕ) (hk : k ≤ 2 ^ 16) (hk_pos : 0 < k)
+    (hk_tab : k ∈ ({1, 3, 5, 30, 34, 36} : Finset ℕ)) :
+    (concreteSpqrErasureCode k hk hk_pos).Correct := by
+  intro M I
+  change
+    (k ≤ I.card →
+        decodeConcrete k hk
+            ((concreteSpqrErasureCode k hk hk_pos).encodeChunks M I) = some M) ∧
+      (I.card < k →
+        decodeConcrete k hk
+            ((concreteSpqrErasureCode k hk hk_pos).encodeChunks M I) = none)
+  rw [encodeChunks_toModel k hk hk_pos hk_tab M I]
+  rw [decode_toModel k hk hk_pos M I]
+  exact (modelEC_correct k hk hk_pos) M I
+
+end Protocols.ErasureCode

--- a/Protocols/ErasureCode/Correct.lean
+++ b/Protocols/ErasureCode/Correct.lean
@@ -5,12 +5,27 @@ Authors: Alessandro D'Angelo
 -/
 import Protocols.ErasureCode.Correctness.Decode
 
-/-! # Correctness of the concrete SPQR erasure code -/
+/-!
+# Correctness of the concrete SPQR erasure code
+
+`ErasureCode` packages deterministic encode and decode functions. Its `Correct` predicate is a
+separate property. The result below proves the deterministic extensional fragment of Definition
+A.6 and strengthens the paper's exactly-`k` clause to recovery from at least `k` honest chunks. It
+establishes no computability, polynomial-time or PPT, asymptotic-cost, or protocol-security
+theorem.
+
+The decoder correspondence covers honest chunks at distinct indices and starts from a fresh
+decoder. Its fold invariant proves that equation without identifying persistent states produced
+by different input orders. It makes no claim about arbitrary input sets or streaming states.
+-/
 
 open ErasureCode.SPQRReedSolomon
 
 namespace Protocols.ErasureCode
 
+/-- Package the concrete encoder and decoder for the structural bound `k ≤ 2^16`. This constructor
+supplies `ErasureCode` operations. Correctness is the separate theorem below, and extracted
+encoder failures have already been mapped to `default`. -/
 noncomputable def concreteSpqrErasureCode
     (k : ℕ) (hk : k ≤ 2 ^ 16) (hk_pos : 0 < k) :
     ErasureCode (Chunk GF16) where
@@ -37,6 +52,8 @@ theorem encodeChunks_toModel
     (i, (modelEC k hk hk_pos).encode M i)
   exact Prod.ext rfl (encode_toModel k hk hk_pos hk_tab M i)
 
+/-- Correctness for the six supported table sizes. Honest chunks at distinct indices recover the
+message when at least `k` are present and decode to `none` when fewer are present. -/
 theorem concreteSpqrErasureCode_correct
     (k : ℕ) (hk : k ≤ 2 ^ 16) (hk_pos : 0 < k)
     (hk_tab : k ∈ ({1, 3, 5, 30, 34, 36} : Finset ℕ)) :

--- a/Protocols/ErasureCode/Correctness/Decode.lean
+++ b/Protocols/ErasureCode/Correctness/Decode.lean
@@ -1,0 +1,686 @@
+/-
+Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Alessandro D'Angelo
+-/
+import Protocols.ErasureCode.Correctness.Encode
+import Spqr.Specs.Encoding.Polynomial.PolyDecoder.New
+import Spqr.Specs.Encoding.Polynomial.PolyDecoder.AddChunk
+
+/-! # Concrete decoder and its model correspondence -/
+
+open Aeneas Aeneas.Std Result Polynomial
+open ErasureCode.SPQRReedSolomon
+open spqr encoding.polynomial
+
+namespace Protocols.ErasureCode
+
+private theorem ptCmp_eq (a b : Pt) :
+    Pt.Insts.CoreCmpOrd.cmp a b =
+      .ok (compare a.x.value.val b.x.value.val) := by
+  obtain ⟨r, hcall, hr⟩ := WP.spec_imp_exists (Pt.Insts.CoreCmpOrd.cmp_spec a b)
+  rw [hr] at hcall
+  exact hcall
+
+private theorem sortedInsert_fresh
+    (l : List Pt) (p : Pt) (i : ℕ)
+    (hsorted : SortedStore l)
+    (hfresh : ∀ q ∈ l, q.x.value.val ≠ p.x.value.val) :
+    ∃ idx newList,
+      sorted_vec.SortedSet.sortedInsert Pt.Insts.CoreCmpOrd l p i =
+        .ok (idx, none, newList) ∧
+      SortedStore newList ∧
+      newList.length = l.length + 1 ∧
+      ∀ q, q ∈ newList ↔ q ∈ l ∨ q = p := by
+  induction l generalizing i with
+  | nil =>
+      exact ⟨i, [p], rfl, by simp [SortedStore], by simp, fun q => by simp [eq_comm]⟩
+  | cons a rest ih =>
+      have hs := List.pairwise_cons.mp hsorted
+      have hfa := hfresh a (by simp)
+      have hfr : ∀ q ∈ rest, q.x.value.val ≠ p.x.value.val := by
+        intro q hq
+        exact hfresh q (by simp [hq])
+      simp only [sorted_vec.SortedSet.sortedInsert, ptCmp_eq]
+      by_cases hap : a.x.value.val < p.x.value.val
+      · rw [(Nat.compare_eq_lt).2 hap]
+        obtain ⟨idx, newList, hcall, hsorted', hlength, hmem⟩ :=
+          ih (i + 1) hs.2 hfr
+        rw [hcall]
+        refine ⟨idx, a :: newList, rfl,
+          List.Pairwise.cons (fun q hq => ?_) hsorted', by simp [hlength],
+          fun q => by simp only [List.mem_cons, hmem]; tauto⟩
+        rcases (hmem q).mp hq with hq | rfl
+        · exact hs.1 q hq
+        · exact hap
+      · have hpa : p.x.value.val < a.x.value.val := by omega
+        rw [(Nat.compare_eq_gt).2 hpa]
+        refine ⟨i, p :: a :: rest, rfl,
+          List.Pairwise.cons (fun q hq => ?_) hsorted, by simp,
+          fun q => by simp only [List.mem_cons]; tauto⟩
+        rcases List.mem_cons.mp hq with rfl | hq
+        · exact hpa
+        · exact lt_trans hpa (hs.1 q hq)
+
+@[step]
+private theorem sortedSet_push_fresh_spec
+    (s : sorted_vec.SortedSet Pt) (p : Pt)
+    (hroom : s.val.length + 1 ≤ Usize.max)
+    (hsorted : SortedStore s.val)
+    (hfresh : ∀ q ∈ s.val, q.x.value.val ≠ p.x.value.val) :
+    sorted_vec.SortedSet.push Pt.Insts.CoreCmpOrd s p
+      ⦃ ((_, displaced), s') =>
+      displaced = none ∧
+      SortedStore s'.val ∧
+      s'.val.length = s.val.length + 1 ∧
+      ∀ q, q ∈ s'.val ↔ q ∈ s.val ∨ q = p ⦄ := by
+  unfold sorted_vec.SortedSet.push
+  rw [dif_pos hroom]
+  split
+  · rename_i hlast
+    have hs_nil := List.getLast?_eq_none_iff.mp hlast
+    simp [hs_nil, SortedStore]
+  · rename_i last hlast
+    have hlast_mem : last ∈ s.val := by
+      obtain ⟨pre, hpref⟩ := List.getLast?_eq_some_iff.mp hlast
+      rw [hpref]
+      simp
+    have hlast_ne := hfresh last hlast_mem
+    have hcmp := ptCmp_eq p last
+    simp only [hcmp, bind_tc_ok]
+    by_cases hgt : last.x.value.val < p.x.value.val
+    · rw [(Nat.compare_eq_gt).2 hgt]
+      simp only [WP.spec_ok]
+      have hmax : ∀ q ∈ s.val, q.x.value.val < p.x.value.val := by
+        intro q hq
+        obtain ⟨pre, hpref⟩ := List.getLast?_eq_some_iff.mp hlast
+        have hcross := (List.pairwise_append.mp (hpref ▸ hsorted)).2.2
+        rw [hpref] at hq
+        rcases List.mem_append.mp hq with hq | hq
+        · exact lt_trans (hcross q hq last (by simp)) hgt
+        · exact (List.mem_singleton.mp hq).symm ▸ hgt
+      refine ⟨rfl, ?_, by simp, fun q => by simp⟩
+      exact List.pairwise_append.mpr ⟨hsorted, by simp, fun q hq r hr =>
+        (List.mem_singleton.mp hr).symm ▸ hmax q hq⟩
+    · have hlt : p.x.value.val < last.x.value.val := by omega
+      rw [(Nat.compare_eq_lt).2 hlt]
+      obtain ⟨idx, newList, hcall, hsorted', hlength, hmem⟩ :=
+        sortedInsert_fresh s.val p 0 hsorted hfresh
+      obtain ⟨pos, hidx, hpos_le, _⟩ :=
+        sorted_vec.SortedSet.sortedInsert_spec Pt.Insts.CoreCmpOrd
+          s.val p 0 hcall
+      have hbnd : newList.length ≤ Usize.max ∧ idx ≤ Usize.max := by
+        constructor
+        · omega
+        · have hs_bound := s.property
+          omega
+      simp only [hcall, dif_pos hbnd, WP.spec_ok]
+      exact ⟨rfl, hsorted', hlength, hmem⟩
+
+private def StoreInv (l : List Pt) (P : Polynomial GF216)
+    (seen : Finset ℕ) (n k : ℕ) : Prop :=
+  SortedStore l ∧
+  StoreOn l P ∧
+  (∀ p ∈ l, p.x.value.val ∈ seen) ∧
+  Nat.min n k ≤ l.length ∧
+  l.length ≤ n
+
+private theorem StoreInv.promote
+    {l : List Pt} {P : Polynomial GF216} {seen : Finset ℕ}
+    {n k x : ℕ}
+    (hinv : StoreInv l P seen n k) (hfull : k ≤ l.length) :
+    StoreInv l P (insert x seen) (n + 1) k := by
+  refine ⟨hinv.1, hinv.2.1, ?_, ?_, ?_⟩
+  · intro p hp
+    exact Finset.mem_insert_of_mem (hinv.2.2.1 p hp)
+  · exact (Nat.min_le_right (n + 1) k).trans hfull
+  · exact hinv.2.2.2.2.trans (Nat.le_succ n)
+
+private theorem u8_shl8_mod_u16_size (b : U8) :
+    b.val <<< 8 % U16.size = b.val * 256 := by
+  have hb : b.val ≤ 255 := by scalar_tac
+  rw [Nat.shiftLeft_eq]
+  simp only [Nat.reducePow]
+  apply Nat.mod_eq_of_lt
+  have : U16.size = 65536 := by scalar_tac
+  omega
+
+@[step]
+private theorem push_storeInv_spec
+    (s : sorted_vec.SortedSet Pt) (p : Pt)
+    (P : Polynomial GF216) (seen : Finset ℕ) (n k x : ℕ)
+    (hinv : StoreInv s.val P seen n k)
+    (hx : x ∉ seen)
+    (hpx : p.x.value.val = x)
+    (hpon : P.eval p.x.toGF216 = p.y.toGF216)
+    (hroom : s.val.length + 1 ≤ Usize.max) :
+    sorted_vec.SortedSet.push Pt.Insts.CoreCmpOrd s p
+      ⦃ ((_, _), s') => StoreInv s'.val P (insert x seen) (n + 1) k ⦄ := by
+  have hfresh : ∀ q ∈ s.val, q.x.value.val ≠ p.x.value.val := by
+    intro q hq heq
+    apply hx
+    have hq_seen := hinv.2.2.1 q hq
+    simpa only [hpx, heq] using hq_seen
+  apply WP.spec_mono
+    (sortedSet_push_fresh_spec s p hroom hinv.1 hfresh)
+  rintro ⟨⟨_, _⟩, s'⟩ ⟨_, hsorted, hlength, hmem⟩
+  refine ⟨hsorted, ?_, ?_, ?_, ?_⟩
+  · intro q hq
+    rcases (hmem q).mp hq with hq | rfl
+    · exact hinv.2.1 q hq
+    · exact hpon
+  · intro q hq
+    rcases (hmem q).mp hq with hq | rfl
+    · exact Finset.mem_insert_of_mem (hinv.2.2.1 q hq)
+    · simpa only [hpx] using Finset.mem_insert_self x seen
+  · rw [hlength]
+    have hlower := hinv.2.2.2.1
+    have hmin : Nat.min (n + 1) k ≤ Nat.min n k + 1 := by
+      change (if n + 1 ≤ k then n + 1 else k) ≤
+        (if n ≤ k then n else k) + 1
+      split <;> split <;> omega
+    omega
+  · rw [hlength]
+    have hupper := hinv.2.2.2.2
+    omega
+
+/-- Each byte pair of `chunk` stores the evaluation of the matching polynomial at the
+chunk index. -/
+private abbrev ChunkStores (P : ℕ → Polynomial GF216) (chunk : encoding.Chunk) : Prop :=
+  ∀ j, j < 16 →
+    (P j).eval chunk.index.val.toGF216 =
+      Nat.toGF216
+        (256 * (chunk.data.val[2 * j]!).val + (chunk.data.val[2 * j + 1]!).val)
+
+private def DecoderLoopInv (pd : PolyDecoder) (P : ℕ → Polynomial GF216)
+    (seen : Finset ℕ) (n k x t : ℕ) : Prop :=
+  pd.pts_needed.val = 16 * k ∧
+  pd.is_complete = false ∧
+  ∀ j, j < 16 →
+    if j < t then
+      StoreInv (pd.pts[j]!).val (P j) (insert x seen) (n + 1) k
+    else
+      StoreInv (pd.pts[j]!).val (P j) seen n k
+
+set_option maxHeartbeats 1000000 in
+-- `step*` elaborates both push branches of the extracted loop body; the index bookkeeping
+-- shared by every obligation is discharged once, and the obligations (which the two
+-- branches duplicate) are then closed by shape.
+@[step]
+private theorem body_decoderLoopInv_spec
+    (chunk : encoding.Chunk) (iter : core.ops.range.Range Usize)
+    (pd : PolyDecoder) (P : ℕ → Polynomial GF216)
+    (seen : Finset ℕ) (n k : ℕ)
+    (h_end : iter.end.val = 16)
+    (h_start : iter.start.val ≤ 16)
+    (hinv : DecoderLoopInv pd P seen n k chunk.index.val iter.start.val)
+    (hfresh : chunk.index.val ∉ seen)
+    (h_on : ChunkStores P chunk)
+    (h_overflow : chunk.index.val * 16 + 16 ≤ Usize.max)
+    (h_push_cap : ∀ j, j < 16 →
+      (pd.pts[j]!).val.length + 1 ≤ Usize.max) :
+    PolyDecoder.Insts.SpqrEncodingDecoder.add_chunk_loop.body chunk iter pd
+      ⦃ cf =>
+        match cf with
+        | ControlFlow.done pd' =>
+          pd' = pd ∧ iter.start.val = 16
+        | ControlFlow.cont (iter', pd') =>
+          iter.start.val < 16 ∧
+          iter'.start.val = iter.start.val + 1 ∧
+          iter'.end = iter.end ∧
+          DecoderLoopInv pd' P seen n k chunk.index.val
+            (iter.start.val + 1) ⦄ := by
+  unfold PolyDecoder.Insts.SpqrEncodingDecoder.add_chunk_loop.body
+  step*
+  · exact P iter.start.val
+  · exact n
+  · exact k
+  · exact P iter.start.val
+  · exact n
+  · exact k
+  all_goals
+    have h_iter_lt : iter.start.val < iter.end.val := by
+      by_contra h
+      have ho_none := (o_post1 (by omega)).1
+      have hbad := ho_none.symm.trans ‹o = some i›
+      simp at hbad
+    have h_i_eq : i = iter.start := by
+      have hi := ‹o = some i›
+      rw [(o_post2 h_iter_lt).1] at hi
+      exact (Option.some.inj hi).symm
+    have h_lt : iter.start.val < 16 := by omega
+    have h_i1_val : i1.val = chunk.index.val := by
+      rw [i1_post]
+      exact U16.cast_Usize_val_eq chunk.index
+    have h_total : total_idx.val = chunk.index.val * 16 + i.val := by
+      rw [total_idx_post, i2_post, h_i1_val]
+    try
+      have h_poly_val : poly.val = iter.start.val := by
+        rw [poly_post, h_total, h_i_eq]
+        omega
+    try
+      have h_ss_eq : ss = pd.pts.val[poly.val]! := by
+        rw [ss_post1]
+        rw [getElem!_pos (h := by simp; omega)]
+  all_goals
+    first
+    | -- the selected store satisfies the per-store invariant
+      (rw [h_ss_eq, h_poly_val]
+       simpa [DecoderLoopInv] using hinv.2.2 iter.start.val h_lt)
+    | -- the selected store has room for one more point
+      (rw [h_ss_eq, h_poly_val]
+       simpa only [Aeneas.Std.Array.getElem!_Nat_eq] using
+         h_push_cap iter.start.val (by omega))
+    | -- continuation invariant after a successful push
+      (obtain ⟨-, h_start1, h_end1⟩ := o_post2 h_iter_lt
+       refine ⟨by omega, h_start1, h_end1, hinv.1, hinv.2.1, ?_⟩
+       intro j hj
+       have hold := hinv.2.2 j hj
+       rcases Nat.lt_trichotomy j iter.start.val with hj_lt | hj_eq | hj_gt
+       · have hframe : (index_mut_back ss1)[j]! = pd.pts[j]! := by
+           rw [ss_post2]
+           apply Aeneas.Std.Array.getElem!_Nat_set_ne
+           omega
+         rw [if_pos (by omega), hframe]
+         simpa [hj_lt] using hold
+       · subst hj_eq
+         have hselected : (index_mut_back ss1)[iter.start.val]! = ss1 := by
+           rw [ss_post2]
+           apply Aeneas.Std.Array.getElem!_Nat_set_eq
+           exact ⟨h_poly_val, by simpa using hj⟩
+         rw [if_pos (by omega), hselected]
+         exact __post
+       · have hframe : (index_mut_back ss1)[j]! = pd.pts[j]! := by
+           rw [ss_post2]
+           apply Aeneas.Std.Array.getElem!_Nat_set_ne
+           omega
+         rw [if_neg (by omega), hframe]
+         simpa [Nat.not_lt.mpr hj_gt.le] using hold)
+    | -- continuation invariant on the full-store skip path
+      (obtain ⟨-, h_start1, h_end1⟩ := o_post2 h_iter_lt
+       have h_v_eq : v = pd.pts.val[poly.val]! := by
+         rw [v_post, sv_post, ss_post]
+         rw [getElem!_pos (h := by simp; omega)]
+       have h_needed : i12.val = k := by
+         rw [i12_post, hinv.1, h_i_eq]
+         simp [Nat.mul_comm]
+       have h_full : k ≤ (pd.pts[iter.start.val]!).val.length := by
+         have h_len : i12.val ≤ v.val.length := by
+           have hnot := ‹¬ v.len < i12›
+           simp only [UScalar.lt_equiv, alloc.vec.Vec.len_val,
+             alloc.vec.Vec.length] at hnot
+           omega
+         rw [h_needed, h_v_eq, h_poly_val] at h_len
+         simpa only [Aeneas.Std.Array.getElem!_Nat_eq] using h_len
+       have h_promoted :
+           StoreInv (pd.pts[iter.start.val]!).val (P iter.start.val)
+             (insert chunk.index.val seen) (n + 1) k :=
+         StoreInv.promote
+           (by simpa [DecoderLoopInv] using hinv.2.2 iter.start.val h_lt) h_full
+       refine ⟨by omega, h_start1, h_end1, hinv.1, hinv.2.1, ?_⟩
+       intro j hj
+       have hold := hinv.2.2 j hj
+       rcases Nat.lt_trichotomy j iter.start.val with hj_lt | hj_eq | hj_gt
+       · rw [if_pos (by omega)]
+         simpa [hj_lt] using hold
+       · subst hj_eq
+         rw [if_pos (by omega)]
+         exact h_promoted
+       · rw [if_neg (by omega)]
+         simpa [Nat.not_lt.mpr hj_gt.le] using hold)
+    | -- the pushed point lies on the selected polynomial
+      (have h_i_lt : i.val < 16 := by
+         rw [h_i_eq]
+         exact h_lt
+       have h_poly_idx_val : poly_idx.val = chunk.index.val := by
+         rw [poly_idx_post, h_total, h_i_eq]
+         omega
+       have h_x_val : x.value.val = chunk.index.val := by
+         simp [x_post, i3_post]
+         grind
+       have h_y_val : y.value.val =
+           256 * (chunk.data.val[2 * iter.start.val]!).val +
+             (chunk.data.val[2 * iter.start.val + 1]!).val := by
+         simp [y_post, i9_post, i8_post1, y1_post, y2_post, i5_post,
+           i7_post, i4_post, i6_post, UScalar.cast_val_eq, h_i_eq]
+         grind [u8_shl8_mod_u16_size]
+       simpa only [spqr.encoding.gf.GF16.toGF216, h_x_val, h_y_val] using
+         h_on iter.start.val h_lt)
+
+private def DecoderInv (pd : PolyDecoder) (P : ℕ → Polynomial GF216)
+    (seen : Finset ℕ) (n k : ℕ) : Prop :=
+  pd.pts_needed.val = 16 * k ∧
+  pd.is_complete = false ∧
+  ∀ j, j < 16 → StoreInv (pd.pts[j]!).val (P j) seen n k
+
+@[step]
+private theorem add_chunk_loop_decoderInv_spec
+    (chunk : encoding.Chunk) (iter : core.ops.range.Range Usize)
+    (pd : PolyDecoder) (P : ℕ → Polynomial GF216)
+    (seen : Finset ℕ) (n k : ℕ)
+    (h_end : iter.end.val = 16)
+    (h_start : iter.start.val ≤ 16)
+    (hinv : DecoderLoopInv pd P seen n k chunk.index.val iter.start.val)
+    (hfresh : chunk.index.val ∉ seen)
+    (h_on : ChunkStores P chunk)
+    (hn : n < 2 ^ 16) :
+    PolyDecoder.Insts.SpqrEncodingDecoder.add_chunk_loop iter pd chunk
+      ⦃ pd' => DecoderInv pd' P (insert chunk.index.val seen) (n + 1) k ⦄ := by
+  unfold PolyDecoder.Insts.SpqrEncodingDecoder.add_chunk_loop
+  apply loop.spec_decr_nat
+    (measure := fun p : core.ops.range.Range Usize × PolyDecoder =>
+      p.1.end.val - p.1.start.val)
+    (inv := fun p : core.ops.range.Range Usize × PolyDecoder =>
+      p.1.end.val = 16 ∧ p.1.start.val ≤ 16 ∧
+      DecoderLoopInv p.2 P seen n k chunk.index.val p.1.start.val)
+  · rintro ⟨iter', pd'⟩ ⟨h_end', h_start', hinv'⟩
+    have h_overflow : chunk.index.val * 16 + 16 ≤ Usize.max := by
+      have hidx : chunk.index.val < 2 ^ 16 := by scalar_tac
+      have hmax := Usize.cMax_bound_concrete
+      omega
+    have h_push_cap : ∀ j, j < 16 →
+        (pd'.pts[j]!).val.length + 1 ≤ Usize.max := by
+      intro j hj
+      have hstore := hinv'.2.2 j hj
+      simp only [Aeneas.Std.Array.getElem!_Nat_eq] at hstore ⊢
+      split at hstore
+      · have hupper := hstore.2.2.2.2
+        have hmax := Usize.cMax_bound_concrete
+        omega
+      · have hupper := hstore.2.2.2.2
+        have hmax := Usize.cMax_bound_concrete
+        omega
+    apply WP.spec_mono
+      (body_decoderLoopInv_spec chunk iter' pd' P seen n k h_end'
+        h_start' hinv' hfresh h_on h_overflow h_push_cap)
+    intro cf hcf
+    match cf with
+    | ControlFlow.done pdFinal =>
+      obtain ⟨rfl, h_at_end⟩ := hcf
+      refine ⟨hinv'.1, hinv'.2.1, ?_⟩
+      intro j hj
+      have hstore := hinv'.2.2 j hj
+      simpa [h_at_end, hj] using hstore
+    | ControlFlow.cont (iterNext, pdNext) =>
+      obtain ⟨h_lt, h_start_next, h_end_next, hinv_next⟩ := hcf
+      refine ⟨⟨?_, ?_, ?_⟩, ?_⟩
+      · rw [h_end_next]
+        exact h_end'
+      · rw [h_start_next]
+        omega
+      · rw [h_start_next]
+        exact hinv_next
+      · change iterNext.end.val - iterNext.start.val <
+          iter'.end.val - iter'.start.val
+        rw [h_end_next, h_start_next]
+        have h_end_val : iter'.end.val = 16 := h_end'
+        omega
+  · exact ⟨h_end, h_start, hinv⟩
+
+@[step]
+private theorem add_chunk_decoderInv_spec
+    (chunk : encoding.Chunk) (pd : PolyDecoder)
+    (P : ℕ → Polynomial GF216) (seen : Finset ℕ) (n k : ℕ)
+    (hinv : DecoderInv pd P seen n k)
+    (hfresh : chunk.index.val ∉ seen)
+    (h_on : ChunkStores P chunk)
+    (hn : n < 2 ^ 16) :
+    PolyDecoder.Insts.SpqrEncodingDecoder.add_chunk pd chunk
+      ⦃ pd' => DecoderInv pd' P (insert chunk.index.val seen) (n + 1) k ⦄ := by
+  unfold PolyDecoder.Insts.SpqrEncodingDecoder.add_chunk
+  apply add_chunk_loop_decoderInv_spec chunk
+    { start := 0#usize, «end» := 16#usize } pd P seen n k
+  · rfl
+  · norm_num
+  · refine ⟨hinv.1, hinv.2.1, ?_⟩
+    intro j hj
+    simpa using hinv.2.2 j hj
+  · exact hfresh
+  · exact h_on
+  · exact hn
+
+private def ChunkOn (P : ℕ → Polynomial GF216)
+    (c : Fin (2 ^ 16) × Chunk GF16) : Prop :=
+  ∀ j : Fin 16, (P j.val).eval c.1.val.toGF216 = c.2 j
+
+private theorem toSpqrChunk_on
+    (P : ℕ → Polynomial GF216)
+    (c : Fin (2 ^ 16) × Chunk GF16) (hon : ChunkOn P c) :
+    ChunkStores P (toSpqrChunk c) := by
+  intro j hj
+  rw [toSpqrChunk_index]
+  have hround := congrFun (ofSpqrChunk_toSpqrChunk c) ⟨j, hj⟩
+  exact (hon ⟨j, hj⟩).trans hround.symm
+
+private theorem foldlM_decoderInv_exists
+    (chunks : List (Fin (2 ^ 16) × Chunk GF16))
+    (pd : PolyDecoder) (P : ℕ → Polynomial GF216)
+    (seen : Finset ℕ) (n k : ℕ)
+    (hinv : DecoderInv pd P seen n k)
+    (hnodup : (chunks.map fun c => c.1.val).Nodup)
+    (hfresh : ∀ c ∈ chunks, c.1.val ∉ seen)
+    (hon : ∀ c ∈ chunks, ChunkOn P c)
+    (hbound : n + chunks.length ≤ 2 ^ 16) :
+    ∃ pd' seen',
+      chunks.foldlM
+          (fun d c =>
+            PolyDecoder.Insts.SpqrEncodingDecoder.add_chunk d (toSpqrChunk c)) pd =
+        .ok pd' ∧
+      DecoderInv pd' P seen' (n + chunks.length) k := by
+  induction chunks generalizing pd seen n with
+  | nil =>
+      exact ⟨pd, seen, rfl, by simpa using hinv⟩
+  | cons c rest ih =>
+      simp only [List.map_cons, List.nodup_cons] at hnodup
+      have hc_fresh := hfresh c (by simp)
+      have hrest_fresh : ∀ d ∈ rest, d.1.val ∉ insert c.1.val seen := by
+        intro d hd
+        have hd_not_seen := hfresh d (by simp [hd])
+        have hd_ne : d.1.val ≠ c.1.val := by
+          intro heq
+          apply hnodup.1
+          exact List.mem_map.mpr ⟨d, hd, heq⟩
+        simpa [Finset.mem_insert, hd_ne] using hd_not_seen
+      have hc_on := toSpqrChunk_on P c (hon c (by simp))
+      obtain ⟨pd1, hadd, hinv1⟩ := WP.spec_imp_exists
+        (add_chunk_decoderInv_spec (toSpqrChunk c) pd P seen n k hinv
+          (by simpa [toSpqrChunk_index] using hc_fresh) hc_on (by
+            simp only [List.length_cons] at hbound
+            omega))
+      obtain ⟨pd2, seen2, hrest, hinv2⟩ :=
+        ih pd1 (insert c.1.val seen) (n + 1) hinv1 hnodup.2
+          hrest_fresh (fun d hd => hon d (by simp [hd])) (by
+            simp only [List.length_cons] at hbound
+            omega)
+      refine ⟨pd2, seen2, ?_, ?_⟩
+      · simp only [List.foldlM_cons, hadd, bind_tc_ok]
+        exact hrest
+      · simpa only [List.length_cons,
+          show n + (rest.length + 1) = n + 1 + rest.length from by omega] using hinv2
+
+private noncomputable def messagePolynomials
+    (k : ℕ) (hk : k ≤ 2 ^ 16) (hk_pos : 0 < k)
+    (M : Fin k → Chunk GF16) (j : ℕ) : Polynomial GF216 :=
+  if hj : j < 16 then
+    (concreteParams k hk hk_pos).encodingPolynomial
+      (fun m => M m ⟨j, hj⟩)
+  else
+    0
+
+private theorem messagePolynomials_eval_encode
+    (k : ℕ) (hk : k ≤ 2 ^ 16) (hk_pos : 0 < k)
+    (M : Fin k → Chunk GF16) (i : Fin (2 ^ 16)) (j : Fin 16) :
+    (messagePolynomials k hk hk_pos M j.val).eval i.val.toGF216 =
+      (modelEC k hk hk_pos).encode M i j := by
+  simp [messagePolynomials, modelEC, concreteParams,
+    ErasureCode.SPQRReedSolomon.parallelErasureCode,
+    ErasureCode.SPQRReedSolomon.encode,
+    ErasureCode.ReedSolomon.Parameters.encode]
+
+private theorem messagePolynomials_degree
+    (k : ℕ) (hk : k ≤ 2 ^ 16) (hk_pos : 0 < k)
+    (M : Fin k → Chunk GF16) (j : Fin 16) :
+    (messagePolynomials k hk hk_pos M j.val).degree < k := by
+  simpa [messagePolynomials, concreteParams] using
+    (concreteParams k hk hk_pos).degree_encodingPolynomial_lt
+      (fun m => M m j)
+
+private theorem messagePolynomials_source
+    (k : ℕ) (hk : k ≤ 2 ^ 16) (hk_pos : 0 < k)
+    (M : Fin k → Chunk GF16) (m : Fin k) (j : Fin 16) :
+    (messagePolynomials k hk hk_pos M j.val).eval m.val.toGF216 = M m j := by
+  simpa [messagePolynomials, concreteParams,
+    ErasureCode.ReedSolomon.Parameters.sourcePoint,
+    ErasureCode.ReedSolomon.Parameters.sourceIndex] using
+    (concreteParams k hk hk_pos).eval_encodingPolynomial_source
+      (fun i => M i j) m
+
+private theorem decoderLength_bound (k : ℕ) (hk : k ≤ 2 ^ 16) :
+    32 * k < 2 ^ UScalarTy.Usize.numBits := by
+  rw [UScalarTy.Usize_numBits_eq]
+  have hmax := Usize.cMax_bound_concrete
+  omega
+
+private theorem new_decoderInv_exists
+    (k : ℕ) (hk : k ≤ 2 ^ 16) (P : ℕ → Polynomial GF216) :
+    ∃ pd,
+      PolyDecoder.Insts.SpqrEncodingDecoder.new
+          (Usize.ofNatCore (32 * k) (decoderLength_bound k hk)) =
+        .ok (.Ok pd) ∧
+      DecoderInv pd P ∅ 0 k := by
+  let len : Usize :=
+    Usize.ofNatCore (32 * k) (decoderLength_bound k hk)
+  obtain ⟨r, hcall, hpost⟩ := WP.spec_imp_exists
+    (PolyDecoder.Insts.SpqrEncodingDecoder.new_spec len)
+  have hlen : len.val = 32 * k := by simp [len]
+  have heven : len.val % 2 = 0 := by omega
+  rw [if_pos heven] at hpost
+  match r with
+  | .Ok pd =>
+    refine ⟨pd, by simpa [len] using hcall, ?_⟩
+    have hneeded : pd.pts_needed.val = 16 * k := by
+      rw [hpost.1]
+      change len.val / 2 = 16 * k
+      omega
+    refine ⟨hneeded, hpost.2.2, ?_⟩
+    intro j hj
+    have hget : pd.pts[j]! =
+        (default : sorted_vec.SortedSet Pt) := by
+      simp only [Aeneas.Std.Array.getElem!_Nat_eq, hpost.2.1]
+      rw [getElem!_pos (h := by simp [hj])]
+      rw [List.getElem_replicate]
+    have hstore : (pd.pts[j]!).val = [] := by
+      rw [hget]
+      rfl
+    rw [hstore]
+    simp [StoreInv, SortedStore, StoreOn]
+  | .Err e =>
+    exact hpost.elim
+
+noncomputable def decodeConcrete (k : ℕ) (hk : k ≤ 2 ^ 16)
+    (L : Finset (Fin (2 ^ 16) × Chunk GF16)) : Option (Fin k → Chunk GF16) :=
+  match spqr.encoding.polynomial.PolyDecoder.Insts.SpqrEncodingDecoder.new
+      (Usize.ofNatCore (32 * k) (decoderLength_bound k hk)) with
+  | .ok (.Ok d0) =>
+      match L.toList.foldlM
+          (fun d c =>
+            spqr.encoding.polynomial.PolyDecoder.Insts.SpqrEncodingDecoder.add_chunk
+              d (toSpqrChunk c)) d0 with
+      | .ok d =>
+          match
+              spqr.encoding.polynomial.PolyDecoder.Insts.SpqrEncodingDecoder.decoded_message d with
+          | .ok (some b) => messageOfBytes k b
+          | _ => none
+      | _ => none
+  | _ => none
+
+private theorem decodeConcrete_eq (k : ℕ) (hk : k ≤ 2 ^ 16)
+    {L : Finset (Fin (2 ^ 16) × Chunk GF16)} {d0 d : PolyDecoder}
+    {r : Option (alloc.vec.Vec U8)}
+    (hnew : PolyDecoder.Insts.SpqrEncodingDecoder.new
+        (Usize.ofNatCore (32 * k) (decoderLength_bound k hk)) = .ok (.Ok d0))
+    (hfold : L.toList.foldlM
+        (fun d c =>
+          PolyDecoder.Insts.SpqrEncodingDecoder.add_chunk d (toSpqrChunk c)) d0 =
+      .ok d)
+    (hdec : PolyDecoder.Insts.SpqrEncodingDecoder.decoded_message d = .ok r) :
+    decodeConcrete k hk L = r.bind (messageOfBytes k) := by
+  unfold decodeConcrete
+  simp only [hnew, hfold, hdec]
+  cases r <;> rfl
+
+theorem decode_toModel (k : ℕ) (hk : k ≤ 2 ^ 16) (hk_pos : 0 < k)
+    (M : Fin k → Chunk GF16) (I : Finset (Fin (2 ^ 16))) :
+    decodeConcrete k hk ((modelEC k hk hk_pos).encodeChunks M I) =
+      (modelEC k hk hk_pos).decode ((modelEC k hk hk_pos).encodeChunks M I) := by
+  classical
+  let P := messagePolynomials k hk hk_pos M
+  let chunks : List (Fin (2 ^ 16) × Chunk GF16) :=
+    ((modelEC k hk hk_pos).encodeChunks M I).toList
+  obtain ⟨d0, hnew, hd0⟩ := new_decoderInv_exists k hk P
+  have hmem : ∀ c, c ∈ chunks ↔
+      c.1 ∈ I ∧ c.2 = (modelEC k hk hk_pos).encode M c.1 := fun c =>
+    Finset.mem_toList.trans ((modelEC k hk hk_pos).mem_encodeChunks M I c)
+  have hchunks_length : chunks.length = I.card :=
+    (Finset.length_toList _).trans ((modelEC k hk hk_pos).card_encodeChunks M I)
+  have hindices : (chunks.map fun c => c.1.val).Nodup := by
+    refine (Finset.nodup_toList _).map_on ?_
+    intro a ha b hb hab
+    have ha_enc := (hmem a).mp ha
+    have hb_enc := (hmem b).mp hb
+    have hindex : a.1 = b.1 := Fin.ext hab
+    exact Prod.ext hindex (by rw [ha_enc.2, hb_enc.2, hindex])
+  have hchunks_on : ∀ c ∈ chunks, ChunkOn P c := by
+    intro c hc j
+    rw [((hmem c).mp hc).2]
+    simpa [P] using messagePolynomials_eval_encode k hk hk_pos M c.1 j
+  obtain ⟨d, seen, hfold, hdinv⟩ :=
+    foldlM_decoderInv_exists chunks d0 P ∅ 0 k hd0 hindices (by simp) hchunks_on
+      (by simpa [hchunks_length] using Finset.card_le_univ I)
+  have hdinv' : DecoderInv d P seen I.card k := by
+    simpa only [Nat.zero_add, hchunks_length] using hdinv
+  have hneeded : ∀ j, j < 16 → neededPoints d j = k := by
+    intro j hj
+    unfold neededPoints
+    rw [hdinv'.1]
+    simp [Nat.mul_comm]
+  by_cases hcard : k ≤ I.card
+  · -- enough chunks: both decoders recover `M`
+    have hdegree : ∀ j, j < 16 →
+        (P j).degree < (neededPoints d j : WithBot ℕ) := fun j hj => by
+      simpa [P, hneeded j hj] using messagePolynomials_degree k hk hk_pos M ⟨j, hj⟩
+    have hlength : ∀ j, j < 16 →
+        neededPoints d j ≤ (d.pts[j]!).val.length := fun j hj => by
+      have hlower := (hdinv'.2.2 j hj).2.2.2.1
+      have hmin : I.card.min k = k := Nat.min_eq_right hcard
+      rw [hmin] at hlower
+      simpa [hneeded j hj] using hlower
+    obtain ⟨r, hdecoded, hpost⟩ := WP.spec_imp_exists
+      (decoded_message_spec_complete d P hdinv'.2.1
+        (fun j hj => (hdinv'.2.2 j hj).1) (fun j hj => (hdinv'.2.2 j hj).2.1)
+        hdegree hlength)
+    obtain ⟨out, rfl, hout_length, hout_pairs⟩ := hpost
+    rw [((modelEC_correct k hk hk_pos) M I).1 hcard,
+      decodeConcrete_eq k hk hnew hfold hdecoded, Option.bind_some]
+    apply messageOfBytes_eq_some_of_pairs
+    · simpa [hdinv'.1] using hout_length
+    · intro m c
+      have hp := hout_pairs (16 * m.val + c.val) (by rw [hdinv'.1]; omega)
+      have hmod : (16 * m.val + c.val) % 16 = c.val := by omega
+      have hdiv : (16 * m.val + c.val) / 16 = m.val := by omega
+      rw [hmod, hdiv] at hp
+      exact hp.trans (by simpa [P] using messagePolynomials_source k hk hk_pos M m c)
+  · -- not enough chunks: both decoders fail
+    have hshort : ∃ j, j < 16 ∧ (d.pts[j]!).val.length < neededPoints d j := by
+      refine ⟨0, by omega, ?_⟩
+      have hupper := (hdinv'.2.2 0 (by omega)).2.2.2.2
+      rw [hneeded 0 (by omega)]
+      omega
+    obtain ⟨r, hdecoded, hr⟩ := WP.spec_imp_exists
+      (decoded_message_spec_short d hshort)
+    subst hr
+    rw [((modelEC_correct k hk hk_pos) M I).2 (show I.card < k by omega),
+      decodeConcrete_eq k hk hnew hfold hdecoded]
+    rfl
+
+end Protocols.ErasureCode

--- a/Protocols/ErasureCode/Correctness/Encode.lean
+++ b/Protocols/ErasureCode/Correctness/Encode.lean
@@ -1,0 +1,129 @@
+/-
+Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Alessandro D'Angelo
+-/
+import Protocols.ErasureCode.Correctness.Params
+import Spqr.Math.Poly.Lagrange.Interpolant
+import Spqr.Specs.Encoding.Polynomial.PolyEncoder.EncodeBytes
+import Spqr.Specs.Encoding.Polynomial.PolyEncoder.ChunkAt
+
+/-! # Concrete encoder and its model correspondence -/
+
+open Aeneas Aeneas.Std Result Polynomial
+open ErasureCode.SPQRReedSolomon
+
+namespace Protocols.ErasureCode
+
+private theorem sum_scaledLagrangeBasis_eq_interpolate_of_val_eq
+    {N : Usize} {k : ℕ} (hNk : N.val = k) (hN : N.val ≤ 2 ^ 16)
+    (y : Fin k → GF216) :
+    (∑ m : Fin k,
+        Polynomial.C (y m) *
+          spqr.encoding.polynomial.scaledLagrangeBasis N m.val) =
+      Lagrange.interpolate Finset.univ
+        (fun m : Fin k => Nat.toGF216 m.val) y := by
+  subst k
+  exact spqr.encoding.polynomial.sum_scaledLagrangeBasis_eq_interpolate hN y
+
+noncomputable def encodeConcrete (k : ℕ) (hk : k ≤ 2 ^ 16)
+    (M : Fin k → Chunk GF16) (i : Fin (2 ^ 16)) : Chunk GF16 :=
+  match spqr.encoding.polynomial.PolyEncoder.Insts.SpqrEncodingEncoder.encode_bytes
+      (bytesOfMessage hk M) with
+  | .ok (.Ok enc) =>
+      match spqr.encoding.polynomial.PolyEncoder.chunk_at enc
+          (U16.ofNatCore i.val (by
+            simpa only [UScalarTy.U16_numBits_eq] using i.isLt)) with
+      | .ok (c, _) => ofSpqrChunk c
+      | _ => default
+  | _ => default
+
+theorem encode_toModel (k : ℕ) (hk : k ≤ 2 ^ 16) (hk_pos : 0 < k)
+    (hk_tab : k ∈ ({1, 3, 5, 30, 34, 36} : Finset ℕ))
+    (M : Fin k → Chunk GF16) (i : Fin (2 ^ 16)) :
+    encodeConcrete k hk M i = (modelEC k hk hk_pos).encode M i := by
+  classical
+  have hk_cases := hk_tab
+  simp only [Finset.mem_insert, Finset.mem_singleton] at hk_cases
+  have hk_le : k ≤ 36 := by
+    omega
+  have hmsg_len := bytesOfMessage_length hk M
+  have h_even : (bytesOfMessage hk M).length % 2 = 0 := by
+    rw [hmsg_len]
+    omega
+  have h_len : (bytesOfMessage hk M).length ≤ 2 ^ 16 * 16 := by
+    rw [hmsg_len]
+    omega
+  obtain ⟨r, hencode, hr⟩ := WP.spec_imp_exists
+    (spqr.encoding.polynomial.PolyEncoder.Insts.SpqrEncodingEncoder.encode_bytes_spec
+      (bytesOfMessage hk M) h_even h_len)
+  cases r with
+  | Err err => simp at hr
+  | Ok enc =>
+    cases enc with
+    | mk encIdx state =>
+      cases state with
+      | Polys polys => simp at hr
+      | Points pts =>
+        simp only at hr
+        have hpts_length (j : ℕ) (hj : j < 16) :
+            (pts[j]!).value.length = k := by
+          rw [hr.2.1 j hj, hmsg_len]
+          rw [show 32 * k / 2 = 16 * k from by omega, show (16 * k) % 16 = 0 from by omega,
+            show 16 * k / 16 = k from by omega]
+          simp
+        let idx : U16 := U16.ofNatCore i.val (by
+          simpa only [UScalarTy.U16_numBits_eq] using i.isLt)
+        have hidx_val : idx.val = i.val := by
+          simp only [idx, U16.ofNatCore_val_eq]
+        have hidx_overflow : idx.val * 16 + 16 ≤ Usize.max := by
+          have hmax := Usize.cMax_bound_concrete.1
+          omega
+        have hadmissible : ∀ (j : Nat), j < 16 →
+            let len := (pts[j]!).value.length
+            len = 0 ∨ len = 1 ∨ len = 3 ∨ len = 5 ∨
+            len = 30 ∨ len = 34 ∨ len = 36 := by
+          intro j hj
+          simp only [hpts_length j hj]
+          omega
+        obtain ⟨out, hchunk, hout⟩ := WP.spec_imp_exists
+          (spqr.encoding.polynomial.PolyEncoder.chunk_at_spec_points
+            { idx := encIdx, s := .Points pts } idx pts rfl
+            hidx_overflow hadmissible)
+        rcases out with ⟨chunk, enc'⟩
+        simp only at hout
+        have hconcrete : encodeConcrete k hk M i = ofSpqrChunk chunk := by
+          simp only [encodeConcrete, hencode, idx, hchunk]
+        rw [hconcrete]
+        funext c
+        unfold ofSpqrChunk
+        rw [hout.2.2 c.val c.isLt]
+        have hstored (m : Fin k) :
+            ((pts[c.val]!).value[m.val]!).toGF216 = M m c := by
+          rw [alloc.vec.Vec.getElem!_Nat_eq]
+          rw [spqr.encoding.polynomial.getElem!_toGF216_eq_coeff]
+          rw [(hr.2.2 c.val c.isLt m.val (by
+            rw [hpts_length c.val c.isLt]
+            exact m.isLt)).2]
+          have hoffset : c.val + 16 * m.val = 16 * m.val + c.val := by omega
+          rw [hoffset]
+          simp only [Slice.getElem!_Nat_eq]
+          exact bytesOfMessage_pair hk M m c
+        have hpoly :
+            (∑ n ∈ Finset.range (pts[c.val]!).value.length,
+                Polynomial.C (((pts[c.val]!).value[n]!).toGF216) *
+                  spqr.encoding.polynomial.scaledLagrangeBasis
+                    (pts[c.val]!).value.len n) =
+              Lagrange.interpolate Finset.univ
+                (fun m : Fin k => Nat.toGF216 m.val) (fun m => M m c) := by
+          rw [hpts_length c.val c.isLt]
+          rw [← Fin.sum_univ_eq_sum_range]
+          simp_rw [hstored]
+          exact sum_scaledLagrangeBasis_eq_interpolate_of_val_eq
+            (by rw [alloc.vec.Vec.len_val, hpts_length c.val c.isLt])
+            (by rw [alloc.vec.Vec.len_val, hpts_length c.val c.isLt]; exact hk)
+            (fun m => M m c)
+        rw [hpoly, hidx_val]
+        rfl
+
+end Protocols.ErasureCode

--- a/Protocols/ErasureCode/Correctness/Encode.lean
+++ b/Protocols/ErasureCode/Correctness/Encode.lean
@@ -8,7 +8,14 @@ import Spqr.Math.Poly.Lagrange.Interpolant
 import Spqr.Specs.Encoding.Polynomial.PolyEncoder.EncodeBytes
 import Spqr.Specs.Encoding.Polynomial.PolyEncoder.ChunkAt
 
-/-! # Concrete encoder and its model correspondence -/
+/-!
+# Concrete encoder and its model correspondence
+
+`encodeConcrete` maps failures from the extracted encoder constructor or chunk lookup to
+`default`, making it a total Lean function. `encode_toModel` proves agreement with the
+Reed–Solomon model when `k ∈ {1, 3, 5, 30, 34, 36}`. The definition does not preserve extracted
+failures or guarantee correctness for other values of `k`.
+-/
 
 open Aeneas Aeneas.Std Result Polynomial
 open ErasureCode.SPQRReedSolomon
@@ -26,6 +33,8 @@ private theorem sum_scaledLagrangeBasis_eq_interpolate_of_val_eq
   subst k
   exact spqr.encoding.polynomial.sum_scaledLagrangeBasis_eq_interpolate hN y
 
+/-- Run the extracted polynomial encoder at index `i`, returning `default` if construction or
+chunk lookup fails. `encode_toModel` proves agreement for the six supported table sizes. -/
 noncomputable def encodeConcrete (k : ℕ) (hk : k ≤ 2 ^ 16)
     (M : Fin k → Chunk GF16) (i : Fin (2 ^ 16)) : Chunk GF16 :=
   match spqr.encoding.polynomial.PolyEncoder.Insts.SpqrEncodingEncoder.encode_bytes

--- a/Protocols/ErasureCode/Correctness/Maps.lean
+++ b/Protocols/ErasureCode/Correctness/Maps.lean
@@ -1,0 +1,168 @@
+/-
+Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Alessandro D'Angelo
+-/
+import Protocols.ErasureCode.Model.SPQRReedSolomon.Correctness
+import Spqr.Math.Gf16.Equiv
+
+/-! # Concrete SPQR byte and chunk representation maps -/
+
+open Aeneas Aeneas.Std
+open ErasureCode.SPQRReedSolomon
+
+namespace Protocols.ErasureCode
+
+private noncomputable def highByte (x : GF216) : U8 :=
+  U8.ofNatCore (GF216.toNat x / 256) (by
+    have h := GF216.toNat_lt x
+    simp only [UScalarTy.U8_numBits_eq, Nat.reducePow]
+    omega)
+
+private noncomputable def lowByte (x : GF216) : U8 :=
+  U8.ofNatCore (GF216.toNat x % 256) (by
+    simp only [UScalarTy.U8_numBits_eq, Nat.reducePow]
+    exact Nat.mod_lt _ (by omega))
+
+@[simp] private theorem highByte_val (x : GF216) :
+    (highByte x).val = GF216.toNat x / 256 := by
+  simp only [highByte, U8.ofNatCore_val_eq]
+
+@[simp] private theorem lowByte_val (x : GF216) :
+    (lowByte x).val = GF216.toNat x % 256 := by
+  simp only [lowByte, U8.ofNatCore_val_eq]
+
+private theorem highByte_lowByte (x : GF216) :
+    Nat.toGF216 (256 * (highByte x).val + (lowByte x).val) = x := by
+  rw [highByte_val, lowByte_val]
+  calc
+    Nat.toGF216 (256 * (GF216.toNat x / 256) + GF216.toNat x % 256) =
+        Nat.toGF216 (GF216.toNat x) := by congr 1; omega
+    _ = x := GF216.toGF216_toNat x
+
+private noncomputable def wordByte (x : GF216) (i : Nat) : U8 :=
+  if i % 2 = 0 then highByte x else lowByte x
+
+private noncomputable def chunkBytes (c : Chunk GF16) : List U8 :=
+  List.ofFn fun i : Fin 32 =>
+    wordByte (c ⟨i.val / 2, by omega⟩) i.val
+
+private noncomputable def messageBytes {k : ℕ} (M : Fin k → Chunk GF16) : List U8 :=
+  List.ofFn fun i : Fin (32 * k) =>
+    wordByte (M ⟨i.val / 32, by omega⟩
+      ⟨(i.val / 2) % 16, Nat.mod_lt _ (by omega)⟩) i.val
+
+private theorem chunkBytes_even (c : Chunk GF16) (j : Fin 16) :
+    (chunkBytes c)[2 * j.val]! = highByte (c j) := by
+  have hdiv : 2 * j.val / 2 = j.val := by omega
+  unfold chunkBytes
+  rw [List.getElem!_ofFn _ _ (by omega)]
+  simp [wordByte, hdiv]
+
+private theorem chunkBytes_odd (c : Chunk GF16) (j : Fin 16) :
+    (chunkBytes c)[2 * j.val + 1]! = lowByte (c j) := by
+  have hdiv : (2 * j.val + 1) / 2 = j.val := by omega
+  unfold chunkBytes
+  rw [List.getElem!_ofFn _ _ (by omega)]
+  simp [wordByte, hdiv]
+
+private theorem messageBytes_even {k : ℕ} (M : Fin k → Chunk GF16)
+    (m : Fin k) (c : Fin 16) :
+    (messageBytes M)[2 * (16 * m.val + c.val)]! = highByte (M m c) := by
+  have hm : 2 * (16 * m.val + c.val) / 32 = m.val := by omega
+  unfold messageBytes
+  rw [List.getElem!_ofFn _ _ (by omega)]
+  simp [wordByte, hm, Nat.mod_eq_of_lt c.isLt]
+
+private theorem messageBytes_odd {k : ℕ} (M : Fin k → Chunk GF16)
+    (m : Fin k) (c : Fin 16) :
+    (messageBytes M)[2 * (16 * m.val + c.val) + 1]! = lowByte (M m c) := by
+  have hm : (2 * (16 * m.val + c.val) + 1) / 32 = m.val := by omega
+  have hc : ((2 * (16 * m.val + c.val) + 1) / 2) % 16 = c.val := by omega
+  unfold messageBytes
+  rw [List.getElem!_ofFn _ _ (by omega)]
+  simp [wordByte, hm, hc]
+
+noncomputable def ofSpqrChunk (c : spqr.encoding.Chunk) : Chunk GF16 :=
+  fun j => Nat.toGF216
+    (256 * (c.data.val[2 * j.val]!).val + (c.data.val[2 * j.val + 1]!).val)
+
+noncomputable def toSpqrChunk (p : Fin (2 ^ 16) × Chunk GF16) : spqr.encoding.Chunk where
+  index := U16.ofNatCore p.1.val (by
+    simpa only [UScalarTy.U16_numBits_eq] using p.1.isLt)
+  data := ⟨chunkBytes p.2, by simp [chunkBytes]⟩
+
+noncomputable def bytesOfMessage {k : ℕ} (hk : k ≤ 2 ^ 16)
+    (M : Fin k → Chunk GF16) : Slice U8 :=
+  ⟨messageBytes M, by
+    simp only [messageBytes, List.length_ofFn]
+    have := Usize.cMax_bound_concrete
+    omega⟩
+
+noncomputable def messageOfBytes (k : ℕ) (b : alloc.vec.Vec Std.U8) :
+    Option (Fin k → Chunk GF16) :=
+  if b.length = 32 * k then
+    some fun m c => Nat.toGF216
+      (256 * (b.val[2 * (16 * m.val + c.val)]!).val +
+        (b.val[2 * (16 * m.val + c.val) + 1]!).val)
+  else none
+
+theorem bytesOfMessage_length {k : ℕ} (hk : k ≤ 2 ^ 16)
+    (M : Fin k → Chunk GF16) :
+    (bytesOfMessage hk M).length = 32 * k := by
+  simp [bytesOfMessage, messageBytes]
+
+theorem bytesOfMessage_pair {k : ℕ} (hk : k ≤ 2 ^ 16)
+    (M : Fin k → Chunk GF16) (m : Fin k) (c : Fin 16) :
+    Nat.toGF216 (256 * ((bytesOfMessage hk M).val[2 * (16 * m.val + c.val)]!).val
+        + ((bytesOfMessage hk M).val[2 * (16 * m.val + c.val) + 1]!).val) = M m c := by
+  change Nat.toGF216
+    (256 * ((messageBytes M)[2 * (16 * m.val + c.val)]!).val +
+      ((messageBytes M)[2 * (16 * m.val + c.val) + 1]!).val) = M m c
+  rw [messageBytes_even, messageBytes_odd]
+  exact highByte_lowByte (M m c)
+
+theorem ofSpqrChunk_toSpqrChunk (p : Fin (2 ^ 16) × Chunk GF16) :
+    ofSpqrChunk (toSpqrChunk p) = p.2 := by
+  funext j
+  change Nat.toGF216
+    (256 * ((chunkBytes p.2)[2 * j.val]!).val +
+      ((chunkBytes p.2)[2 * j.val + 1]!).val) = p.2 j
+  rw [chunkBytes_even, chunkBytes_odd]
+  exact highByte_lowByte (p.2 j)
+
+theorem toSpqrChunk_index (p : Fin (2 ^ 16) × Chunk GF16) :
+    (toSpqrChunk p).index.val = p.1.val := by
+  simp [toSpqrChunk]
+
+theorem messageOfBytes_some_iff (k : ℕ) (b : alloc.vec.Vec Std.U8) :
+    (messageOfBytes k b).isSome ↔ b.length = 32 * k := by
+  simp [messageOfBytes]
+
+theorem messageOfBytes_eq_some_of_pairs (k : ℕ) (b : alloc.vec.Vec Std.U8)
+    (M : Fin k → Chunk GF16) (hlen : b.length = 2 * (16 * k))
+    (hpair : ∀ (m : Fin k) (c : Fin 16),
+      Nat.toGF216 (256 * (b.val[2 * (16 * m.val + c.val)]!).val
+          + (b.val[2 * (16 * m.val + c.val) + 1]!).val) = M m c) :
+    messageOfBytes k b = some M := by
+  unfold messageOfBytes
+  split
+  · congr
+    funext m c
+    exact hpair m c
+  · rename_i h
+    exfalso
+    apply h
+    omega
+
+theorem messageOfBytes_bytesOfMessage {k : ℕ} (hk : k ≤ 2 ^ 16)
+    (M : Fin k → Chunk GF16) :
+    messageOfBytes k
+      ⟨(bytesOfMessage hk M).val, by simpa using (bytesOfMessage hk M).property⟩ = some M := by
+  apply messageOfBytes_eq_some_of_pairs
+  · change (bytesOfMessage hk M).length = 2 * (16 * k)
+    rw [bytesOfMessage_length]
+    omega
+  · exact bytesOfMessage_pair hk M
+
+end Protocols.ErasureCode

--- a/Protocols/ErasureCode/Correctness/Params.lean
+++ b/Protocols/ErasureCode/Correctness/Params.lean
@@ -1,0 +1,34 @@
+/-
+Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Alessandro D'Angelo
+-/
+import Protocols.ErasureCode.Contract
+
+/-! # Concrete Reed–Solomon parameters for SPQR -/
+
+open ErasureCode.SPQRReedSolomon
+
+namespace Protocols.ErasureCode
+
+noncomputable def concreteParams (k : ℕ) (hk : k ≤ 2 ^ 16) (hk_pos : 0 < k) :
+    ErasureCode.ReedSolomon.Parameters GF16 where
+  N := 2 ^ 16
+  N_pos := by norm_num
+  k := k
+  k_pos := hk_pos
+  k_le_N := hk
+  point := fun i => Nat.toGF216 i.val
+  point_injective := by
+    intro a b hab
+    exact Fin.ext (Nat.toGF216_injOn a.isLt b.isLt hab)
+
+noncomputable def modelEC (k : ℕ) (hk : k ≤ 2 ^ 16) (hk_pos : 0 < k) :
+    ErasureCode (Chunk GF16) :=
+  ErasureCode.SPQRReedSolomon.parallelErasureCode (concreteParams k hk hk_pos)
+
+theorem modelEC_correct (k : ℕ) (hk : k ≤ 2 ^ 16) (hk_pos : 0 < k) :
+    (modelEC k hk hk_pos).Correct :=
+  ErasureCode.SPQRReedSolomon.parallelErasureCode_correct _
+
+end Protocols.ErasureCode

--- a/Protocols/ErasureCode/Model/Defs.lean
+++ b/Protocols/ErasureCode/Model/Defs.lean
@@ -1,0 +1,191 @@
+/-
+Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alessandro D'Angelo
+-/
+
+/- Vendored verbatim (imports rewritten) from
+   https://github.com/Beneficial-AI-Foundation/secure-messaging
+   SecureMessaging/ErasureCode/Defs.lean at commit 2144e35.
+   The canonical copy is secure-messaging; do not edit here — re-vendor. -/
+
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.Finset.Sort
+
+/-!
+# Erasure Codes
+
+Syntax and correctness of erasure codes following Definition A.6 from:
+
+- [SCKA] Auerbach, Dodis, Jost, Katsumata, Schmidt.
+  *How to Compare Bandwidth Constrained Two-Party Secure Messaging Protocols.*
+  USENIX Security 2025, https://eprint.iacr.org/2025/2267.pdf
+
+An *erasure code* over a set of symbols `Σ`, with block length `N` and message size
+`0 < nchunk ≤ N`, consists of two algorithms:
+- `Encode(M, i) → c`: encodes message `M ∈ Σ^nchunk` at a bounded chunk index
+  `i : Fin N` to a symbol `c ∈ Σ`;
+- `Decode(L) → M`: from a chunk set `L ⊆ Fin N × Σ`, recovers `M ∈ Σ^nchunk`
+  or fails with `⊥`.
+
+This model restricts `Encode` and `Decode` to deterministic functions, covering
+deterministic codes such as Reed-Solomon.
+
+A received chunk set `L` is *decodable* for threshold `nchunk` when `nchunk ≤ |L|`
+and the chunks of `L` have pairwise distinct positions.
+
+Writing `L_I = {(i, Encode(M, i)) | i ∈ I}` for the chunks of `M` at indices
+`I ⊆ Fin N`, correctness requires, for all `M` and all `I`:
+- `Decode(L_I) = M, if nchunk ≤ |I|`;
+- `Decode(L_I) = ⊥, if |I| < nchunk`.
+-/
+
+/-- An erasure code over an alphabet `Sym` (Definition A.6 of [SCKA]).
+
+- `Sym`: the alphabet Σ of symbols;
+- `N`: the number of valid encoded-chunk positions; valid indices are
+  `0, …, N - 1`;
+- `nchunk`: the number of source symbols and the number of distinct encoded
+  chunks required to recover the message;
+- `nchunk > 0`: at least one distinct encoded chunk is required for recovery;
+- `encode M i`: the chunk encoding of message `M` at index `i`;
+- `decode L`: recovers a message from a chunk set `L`, or fails (`none`).
+-/
+-- ANCHOR: ErasureCode
+structure ErasureCode (Sym : Type) where
+  /-- Number of valid encoded-chunk positions; valid indices are `0, …, N - 1`. -/
+  N : ℕ
+  /-- At least one encoded-chunk position is available. -/
+  N_pos : 0 < N
+  /-- Number of source symbols and distinct encoded chunks needed for recovery. -/
+  nchunk : ℕ
+  /-- At least one distinct encoded chunk is required for recovery. -/
+  nchunk_pos : 0 < nchunk
+  /-- The message fits within the codeword. -/
+  nchunk_le_N : nchunk ≤ N
+  /-- `Encode(M, i)`: the chunk encoding of message `M` at index `i`. -/
+  encode : (Fin nchunk → Sym) → Fin N → Sym
+  /-- `Decode(L)`: recover the message from a chunk set, or fail (`none`). -/
+  decode : Finset (Fin N × Sym) → Option (Fin nchunk → Sym)
+-- ANCHOR_END: ErasureCode
+
+/-- An erasure code over `Sym` equipped with serialization for payloads of type `M`. -/
+-- ANCHOR: ErasureCodePayload
+structure ErasureCodePayload (M Sym : Type) where
+  /-- The erasure code used for this payload type. -/
+  ec : ErasureCode Sym
+  /-- Serialize a payload as the `nchunk`-symbol message consumed by `ec.encode`. -/
+  serialize : M → Fin ec.nchunk → Sym
+  /-- Parse a decoded `nchunk`-symbol message as a payload, or fail. -/
+  parse : (Fin ec.nchunk → Sym) → Option M
+  /-- Parsing a serialized payload recovers the original payload. -/
+  parse_serialize : ∀ payload, parse (serialize payload) = some payload
+-- ANCHOR_END: ErasureCodePayload
+
+namespace ErasureCodePayload
+
+variable {M Sym : Type}
+
+/-- Map a natural counter index to a bounded chunk position modulo `N`. -/
+def counterIndex (ecp : ErasureCodePayload M Sym) (i : ℕ) : Fin ecp.ec.N :=
+  ⟨i % ecp.ec.N, Nat.mod_lt i ecp.ec.N_pos⟩
+
+/-- Encode at counter `i` modulo `N`, returning the wrapped index and symbol.
+This matches the `ℤ_N` indices in [SCKA] and SPQR's fixed-width chunk index. -/
+def encode (ecp : ErasureCodePayload M Sym) (payload : M) (i : ℕ) : ℕ × Sym :=
+  let j := counterIndex ecp i
+  (j.1, ecp.ec.encode (ecp.serialize payload) j)
+
+/-- Decode received chunks to a payload, rejecting a set containing an index
+outside the valid range `0, …, N - 1`. -/
+def decode (ecp : ErasureCodePayload M Sym) (chunks : Finset (ℕ × Sym)) : Option M :=
+  if hvalid : ∀ chunk ∈ chunks, chunk.1 < ecp.ec.N then
+    let toBounded : {chunk // chunk ∈ chunks} ↪ (Fin ecp.ec.N × Sym) :=
+      { toFun := fun chunk =>
+          (⟨chunk.1.1, hvalid chunk.1 chunk.2⟩, chunk.1.2)
+        inj' := by
+          intro a b hab
+          apply Subtype.ext
+          exact Prod.ext
+            (congrArg (fun chunk : Fin ecp.ec.N × Sym => chunk.1.val) hab)
+            (congrArg (fun chunk : Fin ecp.ec.N × Sym => chunk.2) hab) }
+    match ecp.ec.decode (chunks.attach.map toBounded) with
+    | none => none
+    | some block => ecp.parse block
+  else
+    none
+
+end ErasureCodePayload
+
+namespace ErasureCode
+
+variable {Sym : Type}
+
+/-- A received chunk set is *decodable* for threshold `nchunk` when it contains
+at least `nchunk` chunks at pairwise distinct positions. -/
+-- ANCHOR: Decodable
+def Decodable {N : ℕ} (nchunk : ℕ) (chunks : Finset (Fin N × Sym)) : Prop :=
+  nchunk ≤ chunks.card ∧ Set.InjOn Prod.fst (chunks : Set (Fin N × Sym))
+-- ANCHOR_END: Decodable
+
+/-- The honest chunk set of `M` at positions `I`:
+`{(i, Encode(M, i)) | i ∈ I}`.
+
+The index is retained in each chunk, so distinct positions remain distinct even
+when their encoded symbols are equal. -/
+-- ANCHOR: encodeChunks
+def encodeChunks (ec : ErasureCode Sym)
+    (M : Fin ec.nchunk → Sym) (I : Finset (Fin ec.N)) :
+    Finset (Fin ec.N × Sym) :=
+  I.map {
+    toFun := fun i => (i, ec.encode M i)
+    inj' := fun _ _ h => congrArg Prod.fst h
+  }
+-- ANCHOR_END: encodeChunks
+
+/-- `encodeChunks` contains exactly one indexed chunk for each position in `I`. -/
+@[simp]
+theorem card_encodeChunks (ec : ErasureCode Sym)
+    (M : Fin ec.nchunk → Sym) (I : Finset (Fin ec.N)) :
+    (ec.encodeChunks M I).card = I.card := by
+  simp [encodeChunks]
+
+/-- A pair `(i, c)` belongs to `encodeChunks M I` exactly when `i ∈ I` and
+`c = Encode(M, i)`. -/
+@[simp]
+theorem mem_encodeChunks (ec : ErasureCode Sym)
+    (M : Fin ec.nchunk → Sym) (I : Finset (Fin ec.N)) (chunk : Fin ec.N × Sym) :
+    chunk ∈ ec.encodeChunks M I ↔ chunk.1 ∈ I ∧ chunk.2 = ec.encode M chunk.1 := by
+  simp only [encodeChunks, Finset.mem_map]
+  constructor
+  · rintro ⟨i, hi, rfl⟩
+    exact ⟨hi, rfl⟩
+  · rintro ⟨hi, hvalue⟩
+    exact ⟨chunk.1, hi, Prod.ext rfl hvalue.symm⟩
+
+/-- Honest chunks at positions `I` are decodable exactly when `nchunk ≤ |I|`:
+there is one chunk per index, so the indices are pairwise distinct. -/
+theorem decodable_encodeChunks_of_nchunk_le_card (ec : ErasureCode Sym)
+    (M : Fin ec.nchunk → Sym) (I : Finset (Fin ec.N))
+    (hcard : ec.nchunk ≤ I.card) :
+    Decodable ec.nchunk (ec.encodeChunks M I) := by
+  constructor
+  · calc
+      ec.nchunk ≤ I.card := hcard
+      _ = (ec.encodeChunks M I).card := (ec.card_encodeChunks M I).symm
+  · intro a ha b hb hab
+    have ha' := (ec.mem_encodeChunks M I a).mp ha
+    have hb' := (ec.mem_encodeChunks M I b).mp hb
+    apply Prod.ext hab
+    rw [ha'.2, hb'.2, hab]
+
+/-- Correctness: decoding the chunk set `{(i, Encode(M, i)) | i ∈ I}` recovers
+`M` when `nchunk ≤ |I|` and fails when `|I| < nchunk`. -/
+-- ANCHOR: Correct
+def Correct (ec : ErasureCode Sym) : Prop :=
+  ∀ (M : Fin ec.nchunk → Sym) (I : Finset (Fin ec.N)),
+    (ec.nchunk ≤ I.card → ec.decode (ec.encodeChunks M I) = some M) ∧
+    (I.card < ec.nchunk → ec.decode (ec.encodeChunks M I) = none)
+-- ANCHOR_END: Correct
+
+end ErasureCode

--- a/Protocols/ErasureCode/Model/Defs.lean
+++ b/Protocols/ErasureCode/Model/Defs.lean
@@ -1,13 +1,16 @@
 /-
 Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
-Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Alessandro D'Angelo
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Beneficial AI Foundation
 -/
 
-/- Vendored verbatim (imports rewritten) from
+/- Vendored from
    https://github.com/Beneficial-AI-Foundation/secure-messaging
-   SecureMessaging/ErasureCode/Defs.lean at commit 2144e35.
-   The canonical copy is secure-messaging; do not edit here — re-vendor. -/
+   SecureMessaging/ErasureCode/Defs.lean
+   at commit 2144e3561b3ebf775f973a3c2804a0f8edb77f75.
+   Local adaptation: Alessandro D'Angelo.
+   The canonical copy is secure-messaging; refresh from the pinned source.
+   Local differences: see Protocols/ErasureCode/README.md, Model provenance. -/
 
 import Mathlib.Data.Finset.Card
 import Mathlib.Data.Finset.Sort

--- a/Protocols/ErasureCode/Model/ReedSolomon/Construction.lean
+++ b/Protocols/ErasureCode/Model/ReedSolomon/Construction.lean
@@ -1,0 +1,236 @@
+/-
+Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alessandro D'Angelo
+-/
+
+/- Vendored verbatim (imports rewritten) from
+   https://github.com/Beneficial-AI-Foundation/secure-messaging
+   SecureMessaging/ErasureCode/ReedSolomon/Construction.lean at commit 2144e35.
+   The canonical copy is secure-messaging; do not edit here — re-vendor. -/
+
+import Mathlib.LinearAlgebra.Lagrange
+import Protocols.ErasureCode.Model.Defs
+
+/-!
+# Reed–Solomon Erasure-Code Construction
+
+## References
+
+- [RS60] Reed, Solomon. *Polynomial Codes over Certain Finite Fields.*
+  Journal of the SIAM 8(2), 1960, https://doi.org/10.1137/0108018
+- [RFC5510] Lacan, Roca, Peltotalo, Peltotalo.
+  *Reed-Solomon Forward Error Correction (FEC) Schemes.*
+  RFC 5510, 2009, https://datatracker.ietf.org/doc/rfc5510/
+- [SCKA] Auerbach, Dodis, Jost, Katsumata, Schmidt.
+  *How to Compare Bandwidth Constrained Two-Party Secure Messaging Protocols.*
+  USENIX Security 2025, https://eprint.iacr.org/2025/2267.pdf
+
+## Scope
+
+This file formalizes the algebraic evaluation/interpolation core of Reed–Solomon
+codes and its instantiation as an erasure-code. It does not model the full details
+of the packet-level FEC scheme of [RFC5510].
+
+## Part 1: The Reed–Solomon code
+
+### Valid parameters (`Parameters`)
+
+A Reed–Solomon code [RS60, RFC5510] with parameters `k ≤ N` and
+pairwise distinct evaluation points `x₀, …, x_(N-1) ∈ F` is the linear code
+
+`RS := { (P(x₀), …, P(x_(N-1))) | P ∈ F[X], deg P < k } ⊆ F^N`,
+
+i.e. the set of evaluations of all polynomials of degree less than `k` over
+the points `x₀, …, x_(N-1)`.
+
+The structure `Parameters F` records these parameters: `N`, `k`, and the evaluation points
+as an injective assignment `j ↦ xⱼ` of positions to field elements (field `point`).
+
+### Lagrange interpolation
+
+For any `n` pairwise distinct points `a₀, …, a_(n-1) ∈ F` and any values
+`b₀, …, b_(n-1) ∈ F`, there is exactly one polynomial `Q ∈ F[X]` with
+`deg Q < n` and `Q(aᵢ) = bᵢ` for all `i < n`.
+
+
+### Systematic encoding (`encodingPolynomial`, `encode`)
+
+By Lagrange interpolation at the `k` distinct points `x₀, …, x_(k-1)` with values
+`m₀, …, m_(k-1)`, a message `m = (m₀, …, m_(k-1)) ∈ F^k` determines its *encoding
+polynomial*: the unique `Pₘ ∈ F[X]` with
+
+* `deg Pₘ < k`, and
+* `Pₘ(xᵢ) = mᵢ` for all `i < k`.
+
+The *codeword* of `m` is the evaluation of `Pₘ` at all `N` points:
+
+```text
+position j     :    0        1     ⋯     k-1     │     k      ⋯     N-1
+point xⱼ       :    x₀       x₁    ⋯    x_(k-1)  │    x_k     ⋯    x_(N-1)
+symbol Pₘ(xⱼ)  :  Pₘ(x₀)  Pₘ(x₁)   ⋯  Pₘ(x_(k-1))│  Pₘ(x_k)   ⋯  Pₘ(x_(N-1))
+               =    m₀      m₁     ⋯    m_(k-1)  │
+                  └───── source symbols ───────┘   └── redundancy symbols ──┘
+```
+
+By the interpolation property, the message appears verbatim in the first `k`
+coordinates: this means the code is *systematic*.
+
+### Reconstruction from partial data (`decodingPolynomial`)
+
+Suppose the values `yⱼ = Pₘ(xⱼ)` are known at `n ≥ k` distinct positions `j`. By
+Lagrange interpolation at these `n` points, there is a unique polynomial `Q` with
+`deg Q < n` and `Q(xⱼ) = yⱼ` for all of them. `Pₘ` satisfies both conditions (using
+`deg Pₘ < k ≤ n`), so by uniqueness `Q = Pₘ`, and `(Q(x₀), …, Q(x_(k-1))) = m`
+recovers the message.
+
+## Part 2: Erasure Code Construction
+
+### Recall: erasure codes ([SCKA] Def. A.6)
+
+An erasure code over a set of symbols `Σ`, with block length `N > 0` and message size
+`nchunk ≤ N`, consists of two algorithms:
+
+* `Encode(M, j) → c` — the symbol of message `M ∈ Σ^nchunk` at position
+  `j ∈ {0, …, N-1}`;
+* `Decode(L) → M` — recovery of a message from a chunk set `L ⊆ {0, …, N-1} × Σ`,
+  or failure `⊥`.
+
+A *chunk* of `M` is a pair `(j, Encode(M, j))`. Correctness: any `nchunk` chunks of
+`M` at distinct positions decode to `M`; fewer decode to `⊥`.
+
+### Instantiation (`decode`, `erasureCode`)
+
+Reed–Solomon instantiates this interface with `Σ = F` and `nchunk = k`:
+
+* `Encode(m, j) = Pₘ(xⱼ)`;
+* `Decode(L) = (Q(x₀), …, Q(x_(k-1)))` when `L` is decodable, where `Q` is the interpolant
+  through `{(xⱼ, y) | (j, y) ∈ L}`;
+* `Decode(L) = ⊥` otherwise.
+
+Distinct positions give distinct evaluation points because `point` is injective.
+
+In a sender-receiver protocol, with `n := |L|`, we have:
+
+```text
+send      :  (j, Pₘ(xⱼ))                    one chunk per position j < N
+receive   :  L = {(j₁, y₁), …, (jₙ, yₙ)}    some chunks lost; need n ≥ k
+                                            and distinct positions
+fit       :  Q := interpolant through       deg Q < n
+             (x_(j₁), y₁), …, (x_(jₙ), yₙ)
+output    :  (Q(x₀), …, Q(x_(k-1)))         = (m₀, …, m_(k-1)) when all received
+                                            chunks are honest
+```
+
+`erasureCode` assembles this into the erasure code `(N, nchunk = k, Encode, Decode)`
+over `Σ = F`.
+Correctness is proved in `SecureMessaging.ErasureCode.ReedSolomon.Correctness`
+-/
+
+namespace ErasureCode.ReedSolomon
+
+noncomputable section
+
+open Polynomial
+
+/-- Valid parameters for a Reed–Solomon code over `F`: positions `0, …, N-1`,
+message size `k ≤ N`, and pairwise distinct evaluation points `xⱼ = point j`. -/
+-- ANCHOR: reedSolomon_Parameters
+structure Parameters (F : Type) [Field F] where
+  /-- Number of codeword positions. -/
+  N : ℕ
+  /-- The codeword has at least one position. -/
+  N_pos : 0 < N
+  /-- Number of message symbols and reconstruction threshold. -/
+  k : ℕ
+  /-- At least one message symbol is required for reconstruction. -/
+  k_pos : 0 < k
+  /-- The message fits in the codeword. -/
+  k_le_N : k ≤ N
+  /-- Evaluation point `xⱼ` of each position `j`. -/
+  point : Fin N → F
+  /-- The evaluation points are pairwise distinct. -/
+  point_injective : Function.Injective point
+-- ANCHOR_END: reedSolomon_Parameters
+
+variable {F : Type} [Field F]
+
+namespace Parameters
+
+-- ANCHOR: reedSolomon_sourcePoints
+/-- The inclusion `{0, …, k-1} ↪ {0, …, N-1}`, `i ↦ i`: a message index as a
+codeword position. -/
+def sourceIndex (params : Parameters F) (i : Fin params.k) : Fin params.N :=
+  Fin.castLE params.k_le_N i
+
+/-- The evaluation-point mapping `point : j ↦ xⱼ` restricted to the message
+positions `{0, …, k-1}`: `i ↦ xᵢ`. -/
+def sourcePoint (params : Parameters F) (i : Fin params.k) : F :=
+  params.point (params.sourceIndex i)
+
+/-- The points `x₀, …, x_(k-1)` are pairwise distinct: the restriction of an
+injective mapping is itself injective. -/
+theorem sourcePoint_injective (params : Parameters F) :
+    Function.Injective params.sourcePoint :=
+  params.point_injective.comp (Fin.castLE_injective params.k_le_N)
+-- ANCHOR_END: reedSolomon_sourcePoints
+
+/-- The *encoding polynomial* `Pₘ` of a message `m`: the unique polynomial with
+`deg Pₘ < k` and `Pₘ(xᵢ) = mᵢ` for `i < k`, by Lagrange interpolation at the points
+`x₀, …, x_(k-1)`. -/
+-- ANCHOR: reedSolomon_encodingPolynomial
+def encodingPolynomial (params : Parameters F) (message : Fin params.k → F) : F[X] :=
+  Lagrange.interpolate Finset.univ params.sourcePoint message
+-- ANCHOR_END: reedSolomon_encodingPolynomial
+
+/-- `Encode(m, j) = Pₘ(xⱼ)`: the codeword symbol of message `m` at position `j`. -/
+-- ANCHOR: reedSolomon_encode
+def encode (params : Parameters F) (message : Fin params.k → F) (i : Fin params.N) : F :=
+  (params.encodingPolynomial message).eval (params.point i)
+-- ANCHOR_END: reedSolomon_encode
+
+/-- The interpolant `Q` through the pairs `{(xⱼ, y) | (j, y) ∈ L}` of a received
+chunk set `L`. For honest chunks `y = Pₘ(xⱼ)` at `n ≥ k` distinct positions,
+`Q = Pₘ`. -/
+-- ANCHOR: reedSolomon_decodingPolynomial
+noncomputable def decodingPolynomial (params : Parameters F)
+    (chunks : Finset (Fin params.N × F)) : F[X] :=
+  letI : DecidableEq F := Classical.decEq F
+  Lagrange.interpolate chunks (fun (j, _) => params.point j) (fun (_, y) => y)
+-- ANCHOR_END: reedSolomon_decodingPolynomial
+
+/-- `Decode(L) = (Q(x₀), …, Q(x_(k-1)))` when `L` is decodable, and `⊥` (`none`)
+otherwise.
+
+Conflicting chunks `(j, y₁), (j, y₂)` with `y₁ ≠ y₂` are rejected because they share
+the position `j`. Chunks with distinct positions but corrupted values are
+outside the erasure-only correctness claim.
+-/
+-- ANCHOR: reedSolomon_decode
+noncomputable def decode (params : Parameters F)
+    (chunks : Finset (Fin params.N × F)) : Option (Fin params.k → F) :=
+  letI : Decidable (ErasureCode.Decodable params.k chunks) := Classical.propDecidable _
+  if _h : ErasureCode.Decodable params.k chunks then
+    some fun i => (params.decodingPolynomial chunks).eval (params.sourcePoint i)
+  else
+    none
+-- ANCHOR_END: reedSolomon_decode
+
+/-- The erasure code `(N, nchunk = k, Encode, Decode)` induced by a Reed–Solomon
+code. -/
+-- ANCHOR: reedSolomon_erasureCode
+def erasureCode (params : Parameters F) : ErasureCode F where
+  N := params.N
+  N_pos := params.N_pos
+  nchunk := params.k
+  nchunk_pos := params.k_pos
+  nchunk_le_N := params.k_le_N
+  encode := params.encode
+  decode := params.decode
+-- ANCHOR_END: reedSolomon_erasureCode
+
+end Parameters
+
+end
+
+end ErasureCode.ReedSolomon

--- a/Protocols/ErasureCode/Model/ReedSolomon/Construction.lean
+++ b/Protocols/ErasureCode/Model/ReedSolomon/Construction.lean
@@ -1,13 +1,16 @@
 /-
 Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
-Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Alessandro D'Angelo
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Beneficial AI Foundation
 -/
 
-/- Vendored verbatim (imports rewritten) from
+/- Vendored from
    https://github.com/Beneficial-AI-Foundation/secure-messaging
-   SecureMessaging/ErasureCode/ReedSolomon/Construction.lean at commit 2144e35.
-   The canonical copy is secure-messaging; do not edit here — re-vendor. -/
+   SecureMessaging/ErasureCode/ReedSolomon/Construction.lean
+   at commit 2144e3561b3ebf775f973a3c2804a0f8edb77f75.
+   Local adaptation: Alessandro D'Angelo.
+   The canonical copy is secure-messaging; refresh from the pinned source.
+   Local differences: see Protocols/ErasureCode/README.md, Model provenance. -/
 
 import Mathlib.LinearAlgebra.Lagrange
 import Protocols.ErasureCode.Model.Defs

--- a/Protocols/ErasureCode/Model/ReedSolomon/Correctness.lean
+++ b/Protocols/ErasureCode/Model/ReedSolomon/Correctness.lean
@@ -1,0 +1,159 @@
+/-
+Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alessandro D'Angelo
+-/
+
+/- Vendored verbatim (imports rewritten) from
+   https://github.com/Beneficial-AI-Foundation/secure-messaging
+   SecureMessaging/ErasureCode/ReedSolomon/Correctness.lean at commit 2144e35.
+   The canonical copy is secure-messaging; do not edit here — re-vendor. -/
+
+import Protocols.ErasureCode.Model.ReedSolomon.Construction
+
+/-!
+# Correctness of the Reed–Solomon Erasure Code
+
+In the notation of `SecureMessaging.ErasureCode.ReedSolomon.Construction`, writing
+
+`L_I := {(j, Encode(m, j)) | j ∈ I}`
+
+for the honest chunks of a message `m` at a set of positions `I`, we prove:
+
+* `Encode(m, i) = mᵢ` for `i < k` — the code is systematic (`encode_source`);
+* `Decode(L_I) = m` when `k ≤ |I|` (`decode_encodeChunks_of_k_le_card`);
+* `Decode(L_I) = ⊥` when `|I| < k` (`decode_encodeChunks_of_card_lt`).
+
+Together these give the erasure-code correctness predicate `ErasureCode.Correct`
+for `erasureCode` (`erasureCode_correct`).
+-/
+
+namespace ErasureCode.ReedSolomon
+
+noncomputable section
+
+open Polynomial
+
+variable {F : Type} [Field F]
+
+namespace Parameters
+
+/-- The interpolation property of the encoding polynomial: `Pₘ(xᵢ) = mᵢ` for `i < k`. -/
+theorem eval_encodingPolynomial_source (params : Parameters F)
+    (message : Fin params.k → F) (i : Fin params.k) :
+    (params.encodingPolynomial message).eval (params.sourcePoint i) = message i := by
+  apply Lagrange.eval_interpolate_at_node
+  · exact params.sourcePoint_injective.injOn
+  · simp
+
+/-- The degree bound of the encoding polynomial: `deg Pₘ < k`. -/
+theorem degree_encodingPolynomial_lt (params : Parameters F)
+    (message : Fin params.k → F) :
+    (params.encodingPolynomial message).degree < params.k := by
+  simpa [encodingPolynomial] using
+    (Lagrange.degree_interpolate_lt
+      (s := Finset.univ) message params.sourcePoint_injective.injOn)
+
+/-- The systematic property: `Encode(m, i) = Pₘ(xᵢ) = mᵢ` for message indices `i < k`. -/
+@[simp]
+-- ANCHOR: reedSolomon_systematic
+theorem encode_source (params : Parameters F) (message : Fin params.k → F)
+    (i : Fin params.k) :
+    params.encode message (params.sourceIndex i) = message i := by
+  exact params.eval_encodingPolynomial_source message i
+-- ANCHOR_END: reedSolomon_systematic
+
+/-- The honest chunk set `L_I` is decodable when `k ≤ |I|`: it has one chunk per
+position of `I`. -/
+theorem decodable_encodeChunks_of_k_le_card (params : Parameters F)
+    (message : Fin params.k → F) (I : Finset (Fin params.N))
+    (hcard : params.k ≤ I.card) :
+    ErasureCode.Decodable params.k (params.erasureCode.encodeChunks message I) :=
+  params.erasureCode.decodable_encodeChunks_of_nchunk_le_card message I hcard
+
+/-- Uniqueness of interpolation: for `k ≤ |I|`, the interpolant `Q` through the
+honest chunks `L_I` equals `Pₘ` — both have degree `< |I|` and agree at the `|I|`
+distinct points `{xⱼ | j ∈ I}`. -/
+private theorem encodingPolynomial_eq_decodingInterpolation (params : Parameters F)
+    (message : Fin params.k → F) (I : Finset (Fin params.N))
+    (hcard : params.k ≤ I.card) :
+    params.encodingPolynomial message =
+      params.decodingPolynomial (params.erasureCode.encodeChunks message I) := by
+  classical
+  let chunks : Finset (Fin params.N × F) := params.erasureCode.encodeChunks message I
+  have hdec : ErasureCode.Decodable params.k chunks :=
+    params.decodable_encodeChunks_of_k_le_card message I hcard
+  have hpoints : Set.InjOn (fun ((j, _) : Fin params.N × F) => params.point j)
+      (chunks : Set (Fin params.N × F)) := by
+    intro a ha b hb hab
+    exact hdec.2 ha hb (params.point_injective hab)
+  rw [decodingPolynomial]
+  apply Lagrange.eq_interpolate_of_eval_eq _ hpoints
+  · have hcard' : params.k ≤ chunks.card := hdec.1
+    exact lt_of_lt_of_le
+      (params.degree_encodingPolynomial_lt message) (by exact_mod_cast hcard')
+  · intro chunk hchunk
+    have hmem := (params.erasureCode.mem_encodeChunks message I chunk).mp hchunk
+    exact hmem.2.symm
+
+/-- Reconstruction above the threshold: `Decode(L_I) = m` when `k ≤ |I|`, by
+`Q = Pₘ` and `Pₘ(xᵢ) = mᵢ`. -/
+theorem decode_encodeChunks_of_k_le_card (params : Parameters F)
+    (message : Fin params.k → F) (I : Finset (Fin params.N))
+    (hcard : params.k ≤ I.card) :
+    params.erasureCode.decode
+      (params.erasureCode.encodeChunks message I) = some message := by
+  have hdec := params.decodable_encodeChunks_of_k_le_card message I hcard
+  have hpoly := params.encodingPolynomial_eq_decodingInterpolation message I hcard
+  change params.decode (params.erasureCode.encodeChunks message I) = some message
+  rw [decode]
+  split_ifs with h
+  · congr 1
+    funext i
+    exact
+      (congrArg (fun poly : F[X] => poly.eval (params.sourcePoint i)) hpoly.symm).trans
+        (params.eval_encodingPolynomial_source message i)
+  · exact (h hdec).elim
+
+/-- Failure below the threshold: `Decode(L_I) = ⊥` when `|I| < k`. -/
+theorem decode_encodeChunks_of_card_lt (params : Parameters F)
+    (message : Fin params.k → F) (I : Finset (Fin params.N))
+    (hcard : I.card < params.k) :
+    params.erasureCode.decode
+      (params.erasureCode.encodeChunks message I) = none := by
+  change params.decode (params.erasureCode.encodeChunks message I) = none
+  rw [decode]
+  split_ifs with hdec
+  · apply Nat.not_le_of_lt hcard
+    have hk := hdec.1
+    calc
+      params.k ≤ (params.erasureCode.encodeChunks message I).card := hk
+      _ = I.card := params.erasureCode.card_encodeChunks message I
+  · rfl
+
+/-- Rejection of conflicts: `Decode(L) = ⊥` when the chunks of `L` do not have
+pairwise distinct positions — in particular when `L` contains
+`(j, y₁), (j, y₂)` with `y₁ ≠ y₂`. -/
+theorem decode_eq_none_of_not_injective (params : Parameters F)
+    (chunks : Finset (Fin params.N × F))
+    (hconflict : ¬Set.InjOn Prod.fst (chunks : Set (Fin params.N × F))) :
+    params.decode chunks = none := by
+  simp [decode, ErasureCode.Decodable, hconflict]
+
+/-- The Reed–Solomon erasure code is correct (`ErasureCode.Correct`, [SCKA] Def.
+A.6): for every message `m` and position set `I`, `Decode(L_I) = m` if `k ≤ |I|`,
+and `Decode(L_I) = ⊥` if `|I| < k`. -/
+-- ANCHOR: reedSolomon_erasureCode_correct
+theorem erasureCode_correct (params : Parameters F) : params.erasureCode.Correct
+-- ANCHOR_END: reedSolomon_erasureCode_correct
+    := by
+  intro message I
+  constructor
+  · exact params.decode_encodeChunks_of_k_le_card message I
+  · exact params.decode_encodeChunks_of_card_lt message I
+
+end Parameters
+
+end
+
+end ErasureCode.ReedSolomon

--- a/Protocols/ErasureCode/Model/ReedSolomon/Correctness.lean
+++ b/Protocols/ErasureCode/Model/ReedSolomon/Correctness.lean
@@ -1,13 +1,16 @@
 /-
 Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
-Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Alessandro D'Angelo
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Beneficial AI Foundation
 -/
 
-/- Vendored verbatim (imports rewritten) from
+/- Vendored from
    https://github.com/Beneficial-AI-Foundation/secure-messaging
-   SecureMessaging/ErasureCode/ReedSolomon/Correctness.lean at commit 2144e35.
-   The canonical copy is secure-messaging; do not edit here — re-vendor. -/
+   SecureMessaging/ErasureCode/ReedSolomon/Correctness.lean
+   at commit 2144e3561b3ebf775f973a3c2804a0f8edb77f75.
+   Local adaptation: Alessandro D'Angelo.
+   The canonical copy is secure-messaging; refresh from the pinned source.
+   Local differences: see Protocols/ErasureCode/README.md, Model provenance. -/
 
 import Protocols.ErasureCode.Model.ReedSolomon.Construction
 

--- a/Protocols/ErasureCode/Model/SPQRReedSolomon/Construction.lean
+++ b/Protocols/ErasureCode/Model/SPQRReedSolomon/Construction.lean
@@ -1,0 +1,212 @@
+/-
+Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alessandro D'Angelo
+-/
+
+/- Vendored verbatim (imports rewritten) from
+   https://github.com/Beneficial-AI-Foundation/secure-messaging
+   SecureMessaging/ErasureCode/SPQRReedSolomon/Construction.lean at commit 2144e35.
+   The canonical copy is secure-messaging; do not edit here — re-vendor. -/
+
+import Mathlib.SetTheory.Cardinal.NatCard
+import Mathlib.FieldTheory.Finite.GaloisField
+import Protocols.ErasureCode.Model.ReedSolomon.Construction
+
+/-!
+# Parallel Reed–Solomon Erasure-Code Construction
+
+This module lifts a Reed–Solomon code over `F` to an erasure code over
+16-coordinate chunks `F^16` by running the same code independently on each
+coordinate. This models the parallel structure of Signal's
+[Sparse Post Quantum Ratchet polynomial encoder and decoder]
+(https://github.com/signalapp/SparsePostQuantumRatchet/blob/main/src/encoding/polynomial.rs),
+where a chunk is 16 `u16` values (32 bytes). The final section gives an abstract SPQR
+specialization.
+
+This is an algebraic abstraction, not an exact specification of Signal's
+implementation. It does not model byte serialization, the concrete correspondence
+between `u16` values and `GF(2^16)` elements, or protocol message encoding.
+
+## Parallel 16-coordinate construction (`encode`, `decode`, `parallelErasureCode`)
+
+*Recall:* a Reed–Solomon code with parameters `k ≤ N` and
+pairwise distinct evaluation points `x₀, …, x_(N-1) ∈ F` is the linear code
+
+`RS := { (P(x₀), …, P(x_(N-1))) | P ∈ F[X], deg P < k } ⊆ F^N`,
+
+i.e. the set of evaluations of all polynomials of degree less than `k` over
+the points `x₀, …, x_(N-1)`.
+
+Fix Reed–Solomon parameters (`ReedSolomon.Parameters F`) with `k ≤ N` and
+evaluation points `x_0, …, x_(N-1)`.
+
+A *16-coordinate erasure code* has symbol set `Σ = F^16` and message size `nchunk = k`.
+A source message is `m = (m₀, …, m_(k-1))`, with each `mᵢ ∈ F^16`.
+Encoding and decoding apply the underlying Reed–Solomon code coordinatewise.
+Writing `v[c]` for the `c`-th coordinate of a chunk `v`:
+for each coordinate `c < 16`, the coordinate message
+`(m₀[c], …, m_(k-1)[c])` has its own encoding polynomial `P_c`.
+
+We have:
+
+* `Encode(m, j) = (P₀(xⱼ), …, P₁₅(xⱼ)) ∈ F^16`;
+* `Decode(L)` interpolates each coordinate separately when `L` is decodable —
+  `Q_c` through `{(xⱼ, y[c]) | (j, y) ∈ L}` — and returns
+  `mᵢ = (Q₀(xᵢ), …, Q₁₅(xᵢ))` for `i < k`; otherwise `⊥`.
+
+The full codeword is an array with 16 rows and `N` columns:
+
+```text
+        position j :    0       ⋯      k-1    │     k      ⋯     N-1
+        point xⱼ   :    x₀      ⋯    x_(k-1)  │    x_k     ⋯    x_(N-1)
+
+        row c = 0  :  P₀(x₀)    ⋯  P₀(x_(k-1))│  P₀(x_k)   ⋯  P₀(x_(N-1))
+        row c = 1  :  P₁(x₀)    ⋯  P₁(x_(k-1))│  P₁(x_k)   ⋯  P₁(x_(N-1))
+            ⋮           ⋮             ⋮       │     ⋮             ⋮
+        row c = 15 : P₁₅(x₀)    ⋯ P₁₅(x_(k-1))│ P₁₅(x_k)   ⋯ P₁₅(x_(N-1))
+
+        column j   =    m₀      ⋯   m_(k-1)   │  Encode(m, j) for j ≥ k
+                     └── message chunks ─────┘  └── redundancy chunks ──┘
+```
+
+* Each **row** `c` is one Reed–Solomon codeword: the evaluations of `P_c`, the
+  encoding polynomial of the coordinate message `(m₀[c], …, m_(k-1)[c])`.
+* Each **column** `j` is one chunk `Encode(m, j) ∈ F^16` — the unit that is
+  transmitted, received, or lost. For `j < k` the column is the message chunk `mⱼ`
+  itself (systematic, coordinatewise).
+
+Erasures delete whole columns; decoding interpolates each surviving row and
+re-evaluates it at `x₀, …, x_(k-1)`.
+
+`parallelErasureCode` packages this as an erasure code over the symbol set `Σ = F^16`: one
+codeword position carries one whole chunk.
+
+## Relation to Signal's SPQR instance
+
+Signal treats each 32-byte chunk as 16 `u16` values and applies one Reed–Solomon code
+to each coordinate. The model in this file, `erasureCode k`, specializes `parallelErasureCode`
+to an abstract `GF(2^16)`. It covers the fixed-size inputs used by ML-KEM Braid,
+whose lengths are divisible by 32 bytes. It does not model Signal's more general
+extension to arbitrary even-length byte strings, where the source field elements are
+distributed unevenly among the 16 coordinate polynomials.
+-/
+
+namespace ErasureCode.SPQRReedSolomon
+
+noncomputable section
+
+open Polynomial
+
+/-- A chunk of 16 field elements. For `F = GF(2^16)`, it represents 32 bytes after
+choosing a two-byte representation of field elements. -/
+-- ANCHOR: parallelReedSolomon_Chunk
+abbrev Chunk (F : Type) := Fin 16 → F
+-- ANCHOR_END: parallelReedSolomon_Chunk
+
+variable {F : Type} [Field F]
+
+/-- Encode a chunk message at position `j` by applying the Reed–Solomon encoder
+independently to each of its 16 coordinates:
+`Encode(m, j) = (P₀(xⱼ), …, P₁₅(xⱼ))`. -/
+-- ANCHOR: parallelReedSolomon_encode
+def encode (params : ReedSolomon.Parameters F) (message : Fin params.k → Chunk F)
+    (index : Fin params.N) : Chunk F :=
+  fun coordinate => params.encode (fun i => message i coordinate) index
+-- ANCHOR_END: parallelReedSolomon_encode
+
+/-- Project each received chunk `(j, y)` to its `c`-th coordinate `(j, y[c])`. -/
+-- ANCHOR: parallelReedSolomon_coordinateChunks
+def coordinateChunks (params : ReedSolomon.Parameters F)
+    (chunks : Finset (Fin params.N × Chunk F)) (coordinate : Fin 16) :
+    Finset (Fin params.N × F) := by
+  classical
+  exact chunks.image fun (j, y) => (j, y coordinate)
+-- ANCHOR_END: parallelReedSolomon_coordinateChunks
+
+/-- Decode a received chunk set coordinatewise. For a decodable set, coordinate `c`
+is reconstructed from `Q_c` at the `k` source points; otherwise decoding returns
+`none`. -/
+-- ANCHOR: parallelReedSolomon_decode
+noncomputable def decode (params : ReedSolomon.Parameters F)
+    (chunks : Finset (Fin params.N × Chunk F)) : Option (Fin params.k → Chunk F) :=
+  letI : Decidable (ErasureCode.Decodable params.k chunks) := Classical.propDecidable _
+  if _h : ErasureCode.Decodable params.k chunks then
+    some fun i coordinate =>
+      (params.decodingPolynomial (coordinateChunks params chunks coordinate)).eval
+        (params.sourcePoint i)
+  else
+    none
+-- ANCHOR_END: parallelReedSolomon_decode
+
+/-- Lift a Reed–Solomon code to an erasure code whose symbols are 16-coordinate
+chunks. It retains block length `N` and threshold `k`. -/
+-- ANCHOR: parallelReedSolomon_erasureCode
+def parallelErasureCode (params : ReedSolomon.Parameters F) : ErasureCode (Chunk F) where
+  N := params.N
+  N_pos := params.N_pos
+  nchunk := params.k
+  nchunk_pos := params.k_pos
+  nchunk_le_N := params.k_le_N
+  encode := encode params
+  decode := decode params
+-- ANCHOR_END: parallelReedSolomon_erasureCode
+
+/-! ## Abstract SPQR specialization
+
+Set `N = 2^16` and `F = GF(2^16)`. Since `|{0, …, N-1}| = |F| = 2^16`, we can choose a
+bijection
+
+`x : {0, …, N-1} ≃ F,    j ↦ xⱼ`.
+
+The field elements `xⱼ` are the evaluation points used by each coordinate's
+Reed–Solomon encoder. The Lean definition `spqrEvaluationPoints` realizes this abstract
+choice, `spqrParameters k` forms the parameter set shared by all 16 coordinates,
+and `erasureCode k := parallelErasureCode (spqrParameters k)`.
+-/
+
+/-- An abstract finite field with `2^16` elements for the SPQR specialization. -/
+-- ANCHOR: spqrReedSolomon_GF16
+abbrev GF16 := GaloisField 2 16
+-- ANCHOR_END: spqrReedSolomon_GF16
+
+/-- Classical decidable equality on the abstract field `GF16`. -/
+noncomputable instance gf16DecidableEq : DecidableEq GF16 := Classical.decEq GF16
+
+/-- The abstract field `GF16` has `2^16` elements. -/
+theorem gf16_card : Nat.card GF16 = 2 ^ 16 := by
+  exact GaloisField.card 2 16 (by decide)
+
+/-- The chosen bijection `x : {0, …, 2^16-1} ≃ GF16`, whose values `xⱼ` are the
+Reed–Solomon evaluation points. -/
+-- ANCHOR: spqrReedSolomon_evaluationPoints
+def spqrEvaluationPoints : Fin (2 ^ 16) ≃ GF16 :=
+  (Finite.equivFinOfCardEq gf16_card).symm
+-- ANCHOR_END: spqrReedSolomon_evaluationPoints
+
+/-- The single-coordinate Reed–Solomon parameters shared by all 16 coordinates:
+threshold `k`, block length `2^16`, and evaluation points given by
+`spqrEvaluationPoints`. -/
+-- ANCHOR: spqrReedSolomon_parameters
+def spqrParameters (k : ℕ) (hk : k ≤ 2 ^ 16) (hk_pos : 0 < k) :
+    ReedSolomon.Parameters GF16
+    where
+  N := 2 ^ 16
+  N_pos := by norm_num
+  k := k
+  k_pos := hk_pos
+  k_le_N := hk
+  point := spqrEvaluationPoints
+  point_injective := spqrEvaluationPoints.injective
+-- ANCHOR_END: spqrReedSolomon_parameters
+
+/-- The abstract SPQR erasure code at threshold `k`: the 16-coordinate parallel code
+specialized to `GF16`, with one chunk at each codeword position. -/
+-- ANCHOR: spqrReedSolomon_erasureCode
+def erasureCode (k : ℕ) (hk : k ≤ 2 ^ 16) (hk_pos : 0 < k) : ErasureCode (Chunk GF16) :=
+  parallelErasureCode (spqrParameters k hk hk_pos)
+-- ANCHOR_END: spqrReedSolomon_erasureCode
+
+end
+
+end ErasureCode.SPQRReedSolomon

--- a/Protocols/ErasureCode/Model/SPQRReedSolomon/Construction.lean
+++ b/Protocols/ErasureCode/Model/SPQRReedSolomon/Construction.lean
@@ -1,13 +1,16 @@
 /-
 Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
-Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Alessandro D'Angelo
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Beneficial AI Foundation
 -/
 
-/- Vendored verbatim (imports rewritten) from
+/- Vendored from
    https://github.com/Beneficial-AI-Foundation/secure-messaging
-   SecureMessaging/ErasureCode/SPQRReedSolomon/Construction.lean at commit 2144e35.
-   The canonical copy is secure-messaging; do not edit here — re-vendor. -/
+   SecureMessaging/ErasureCode/SPQRReedSolomon/Construction.lean
+   at commit 2144e3561b3ebf775f973a3c2804a0f8edb77f75.
+   Local adaptation: Alessandro D'Angelo.
+   The canonical copy is secure-messaging; refresh from the pinned source.
+   Local differences: see Protocols/ErasureCode/README.md, Model provenance. -/
 
 import Mathlib.SetTheory.Cardinal.NatCard
 import Mathlib.FieldTheory.Finite.GaloisField

--- a/Protocols/ErasureCode/Model/SPQRReedSolomon/Correctness.lean
+++ b/Protocols/ErasureCode/Model/SPQRReedSolomon/Correctness.lean
@@ -1,0 +1,195 @@
+/-
+Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alessandro D'Angelo
+-/
+
+/- Vendored verbatim (imports rewritten) from
+   https://github.com/Beneficial-AI-Foundation/secure-messaging
+   SecureMessaging/ErasureCode/SPQRReedSolomon/Correctness.lean at commit 2144e35.
+   The canonical copy is secure-messaging; do not edit here — re-vendor. -/
+
+import Protocols.ErasureCode.Model.ReedSolomon.Correctness
+import Protocols.ErasureCode.Model.SPQRReedSolomon.Construction
+
+/-!
+# Correctness of the Parallel Reed–Solomon Erasure Code
+
+Let `params` be Reed–Solomon parameters, `m ∈ (F^16)^k`, and
+`I ⊆ {0, …, N-1}`. Denote by
+
+`L_I := {(j, Encode(m, j)) | j ∈ I}`
+
+the set of chunks at positions `I`. Each of the 16 coordinates forms an ordinary
+Reed–Solomon codeword. We prove:
+
+* `Encode(m, i) = mᵢ` for `i < k` — the parallel code is systematic (`encode_source`);
+* `Decode(L_I) = m` when `k ≤ |I|` (`decode_encodeChunks_of_k_le_card`);
+* `Decode(L_I) = ⊥` when `|I| < k` (`decode_encodeChunks_of_card_lt`);
+* `ErasureCode.Correct` for `parallelErasureCode params`
+  (`parallelErasureCode_correct`) and its specialization `erasureCode k`
+  (`erasureCode_correct`).
+-/
+
+namespace ErasureCode.SPQRReedSolomon
+
+noncomputable section
+
+open Polynomial
+
+variable {F : Type} [Field F]
+
+/-- Systematic encoding: at each source index `i < k`, parallel encoding returns the
+source chunk itself, `Encode(message, i) = message i`. -/
+@[simp]
+theorem encode_source (params : ReedSolomon.Parameters F)
+    (message : Fin params.k → Chunk F) (i : Fin params.k) :
+    encode params message (params.sourceIndex i) = message i := by
+  funext coordinate
+  exact params.encode_source (fun j => message j coordinate) i
+
+/-- If `I` contains at least `k` positions, then the chunk set
+`(parallelErasureCode params).encodeChunks message I` is decodable: it has one chunk per
+position of `I`. -/
+theorem decodable_encodeChunks_of_k_le_card (params : ReedSolomon.Parameters F)
+    (message : Fin params.k → Chunk F) (I : Finset (Fin params.N))
+    (hcard : params.k ≤ I.card) :
+    ErasureCode.Decodable params.k ((parallelErasureCode params).encodeChunks message I) :=
+  (parallelErasureCode params).decodable_encodeChunks_of_nchunk_le_card message I hcard
+
+/-- Projection commutes with encoding: selecting coordinate `c` from every parallel
+encoded chunk over `I` gives exactly the scalar encoded chunk set for the coordinate
+message `i ↦ message i c`. -/
+@[simp]
+theorem coordinateChunks_encodeChunks (params : ReedSolomon.Parameters F)
+    (message : Fin params.k → Chunk F) (I : Finset (Fin params.N))
+    (coordinate : Fin 16) :
+    coordinateChunks params ((parallelErasureCode params).encodeChunks message I) coordinate =
+      params.erasureCode.encodeChunks (fun i => message i coordinate) I := by
+  classical
+  ext chunk
+  constructor
+  · intro hchunk
+    rcases Finset.mem_image.mp hchunk with ⟨fullChunk, hfull, rfl⟩
+    have hmem := ((parallelErasureCode params).mem_encodeChunks message I fullChunk).mp hfull
+    apply (params.erasureCode.mem_encodeChunks (fun i => message i coordinate) I _).mpr
+    refine ⟨hmem.1, ?_⟩
+    exact congrFun hmem.2 coordinate
+  · intro hchunk
+    have hmem :=
+      (params.erasureCode.mem_encodeChunks
+        (fun i => message i coordinate) I chunk).mp hchunk
+    rcases chunk with ⟨index, value⟩
+    let fullChunk := (index, (parallelErasureCode params).encode message index)
+    apply Finset.mem_image.mpr
+    refine ⟨fullChunk, ?_, ?_⟩
+    · exact
+        ((parallelErasureCode params).mem_encodeChunks message I fullChunk).mpr ⟨hmem.1, rfl⟩
+    · change
+        (index, ((parallelErasureCode params).encode message index) coordinate) = (index, value)
+      congr
+      change params.encode (fun i => message i coordinate) index = value
+      exact hmem.2.symm
+
+/-- Coordinatewise interpolation of honest chunks: when `k ≤ |I|`, the decoding
+polynomial for coordinate `c` equals the scalar encoding polynomial of
+`i ↦ message i c`. -/
+private theorem encodingPolynomial_eq_decodingPolynomial
+    (params : ReedSolomon.Parameters F)
+    (message : Fin params.k → Chunk F) (I : Finset (Fin params.N))
+    (hcard : params.k ≤ I.card)
+    (coordinate : Fin 16) :
+    params.encodingPolynomial (fun i => message i coordinate) =
+      params.decodingPolynomial
+        (coordinateChunks params
+          ((parallelErasureCode params).encodeChunks message I) coordinate) := by
+  classical
+  let scalarMessage := fun i => message i coordinate
+  let chunks : Finset (Fin params.N × F) :=
+    params.erasureCode.encodeChunks scalarMessage I
+  have hdec : ErasureCode.Decodable params.k chunks :=
+    params.decodable_encodeChunks_of_k_le_card scalarMessage I hcard
+  have hpoints : Set.InjOn (fun ((j, _) : Fin params.N × F) => params.point j)
+      (chunks : Set (Fin params.N × F)) := by
+    intro a ha b hb hab
+    exact hdec.2 ha hb (params.point_injective hab)
+  rw [coordinateChunks_encodeChunks, ReedSolomon.Parameters.decodingPolynomial]
+  apply Lagrange.eq_interpolate_of_eval_eq _ hpoints
+  · have hdegree := params.degree_encodingPolynomial_lt scalarMessage
+    have hcard' : params.k ≤ chunks.card := hdec.1
+    exact lt_of_lt_of_le hdegree (by exact_mod_cast hcard')
+  · intro chunk hchunk
+    have hmem :=
+      (params.erasureCode.mem_encodeChunks scalarMessage I chunk).mp hchunk
+    exact hmem.2.symm
+
+/-- Reconstruction at or above the threshold: encoding a message at every position in
+`I` and decoding those chunks returns the message whenever `k ≤ |I|`. -/
+theorem decode_encodeChunks_of_k_le_card (params : ReedSolomon.Parameters F)
+    (message : Fin params.k → Chunk F) (I : Finset (Fin params.N))
+    (hcard : params.k ≤ I.card) :
+    (parallelErasureCode params).decode
+      ((parallelErasureCode params).encodeChunks message I) = some message := by
+  have hdec := decodable_encodeChunks_of_k_le_card params message I hcard
+  change decode params ((parallelErasureCode params).encodeChunks message I) = some message
+  rw [decode]
+  split_ifs with h
+  · congr 1
+    funext i coordinate
+    have hpoly :=
+      encodingPolynomial_eq_decodingPolynomial params message I hcard coordinate
+    exact
+      (congrArg (fun poly : F[X] => poly.eval (params.sourcePoint i)) hpoly.symm).trans
+        (params.eval_encodingPolynomial_source (fun j => message j coordinate) i)
+  · exact (h hdec).elim
+
+/-- Failure below the threshold: decoding
+`(parallelErasureCode params).encodeChunks message I` returns `none` whenever `|I| < k`. -/
+theorem decode_encodeChunks_of_card_lt (params : ReedSolomon.Parameters F)
+    (message : Fin params.k → Chunk F) (I : Finset (Fin params.N))
+    (hcard : I.card < params.k) :
+    (parallelErasureCode params).decode
+      ((parallelErasureCode params).encodeChunks message I) = none := by
+  change decode params ((parallelErasureCode params).encodeChunks message I) = none
+  rw [decode]
+  split_ifs with hdec
+  · apply Nat.not_le_of_lt hcard
+    have hk := hdec.1
+    calc
+      params.k ≤ ((parallelErasureCode params).encodeChunks message I).card := hk
+      _ = I.card := (parallelErasureCode params).card_encodeChunks message I
+  · rfl
+
+/-- Rejection of conflicting chunks: decoding returns `none` if two distinct received
+entries share a position. -/
+theorem decode_eq_none_of_not_injective (params : ReedSolomon.Parameters F)
+    (chunks : Finset (Fin params.N × Chunk F))
+    (hconflict : ¬Set.InjOn Prod.fst (chunks : Set (Fin params.N × Chunk F))) :
+    decode params chunks = none := by
+  simp [decode, ErasureCode.Decodable, hconflict]
+
+/-- Correctness of the parallel construction: for every message and position
+set `I`, decoding honest chunks returns the message when `k ≤ |I|` and returns `none`
+when `|I| < k`. -/
+-- ANCHOR: parallelReedSolomon_erasureCode_correct
+theorem parallelErasureCode_correct (params : ReedSolomon.Parameters F) :
+    (parallelErasureCode params).Correct
+-- ANCHOR_END: parallelReedSolomon_erasureCode_correct
+    := by
+  intro message I
+  constructor
+  · exact decode_encodeChunks_of_k_le_card params message I
+  · exact decode_encodeChunks_of_card_lt params message I
+
+/-- Correctness of the abstract SPQR specialization for every threshold
+`0 < k ≤ 2^16`. -/
+-- ANCHOR: spqrReedSolomon_erasureCode_correct
+theorem erasureCode_correct (k : ℕ) (hk : k ≤ 2 ^ 16) (hk_pos : 0 < k) :
+    (erasureCode k hk hk_pos).Correct
+-- ANCHOR_END: spqrReedSolomon_erasureCode_correct
+    := by
+  exact parallelErasureCode_correct (spqrParameters k hk hk_pos)
+
+end
+
+end ErasureCode.SPQRReedSolomon

--- a/Protocols/ErasureCode/Model/SPQRReedSolomon/Correctness.lean
+++ b/Protocols/ErasureCode/Model/SPQRReedSolomon/Correctness.lean
@@ -1,13 +1,16 @@
 /-
 Copyright (c) 2026 Beneficial AI Foundation. All rights reserved.
-Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Alessandro D'Angelo
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Beneficial AI Foundation
 -/
 
-/- Vendored verbatim (imports rewritten) from
+/- Vendored from
    https://github.com/Beneficial-AI-Foundation/secure-messaging
-   SecureMessaging/ErasureCode/SPQRReedSolomon/Correctness.lean at commit 2144e35.
-   The canonical copy is secure-messaging; do not edit here — re-vendor. -/
+   SecureMessaging/ErasureCode/SPQRReedSolomon/Correctness.lean
+   at commit 2144e3561b3ebf775f973a3c2804a0f8edb77f75.
+   Local adaptation: Alessandro D'Angelo.
+   The canonical copy is secure-messaging; refresh from the pinned source.
+   Local differences: see Protocols/ErasureCode/README.md, Model provenance. -/
 
 import Protocols.ErasureCode.Model.ReedSolomon.Correctness
 import Protocols.ErasureCode.Model.SPQRReedSolomon.Construction

--- a/Protocols/ErasureCode/README.md
+++ b/Protocols/ErasureCode/README.md
@@ -1,0 +1,79 @@
+# SPQR erasure-code verification
+
+## What is proved
+
+`concreteSpqrErasureCode_correct` connects the extracted SPQR encoder and decoder to the
+Reed–Solomon model in this directory. For an allowed message size `k`, an honest set of encoded
+chunks at distinct positions decodes to the original message when it contains at least `k`
+chunks, and decoding returns `none` when it contains fewer than `k` chunks.
+
+The proof is split at two correspondence lemmas:
+
+- `encode_toModel` shows that the extracted encoder produces the model's chunk at each index.
+- `decode_toModel` shows that the extracted decoder agrees with the model on honest chunk sets.
+
+This is a functional-correctness result. It does not claim security, cover streaming decode, or
+define an `ErasureCodePayload` instance.
+
+The theorem requires `k ∈ {1, 3, 5, 30, 34, 36}`. These are the point counts supported by the
+precomputed polynomial tables used by the Rust implementation; a theorem for arbitrary `k`
+would not describe the shipped code.
+
+## Assumptions and axiom closure
+
+Rust's `decoded_message` function is deliberately opaque to extraction; see
+[issue #103](https://github.com/Beneficial-AI-Foundation/SparsePostQuantumRatchet-verify/issues/103).
+`Contract.lean` therefore states two assumptions about that real function:
+
+- `decoded_message_spec_short`: if any one of the 16 point stores is short, decoding returns
+  `none`.
+- `decoded_message_spec_complete`: complete, sorted stores containing points on suitably
+  low-degree polynomials decode to the bytes of those polynomial evaluations.
+
+The checked closure of `concreteSpqrErasureCode_correct` contains:
+
+- `propext`, `Classical.choice`, and `Quot.sound`: Lean's standard logical axioms;
+- `decoded_message_spec_short` and `decoded_message_spec_complete`: the two assumptions above;
+- `encoding.polynomial.PolyDecoder.Insts.SpqrEncodingDecoder.decoded_message`: the extraction
+  opaque;
+- <code>sorr&#121;Ax</code>: inherited through the pre-existing named assumption
+  `Spqr.Aeneas.collect_default_bridge`. Aeneas currently mistranslates the relevant mapped
+  iterator ([aeneas#1043](https://github.com/AeneasVerif/aeneas/issues/1043)); project
+  [issue #409](https://github.com/Beneficial-AI-Foundation/SparsePostQuantumRatchet-verify/issues/409)
+  tracks removing this assumption;
+- `Aeneas.Std.core.fmt.Formatter` and the two `RangeFull.get_unchecked` declarations: opaque
+  primitives in the extracted support library;
+- `PolyEncoder.chunk_at._native.decide.ax_1` and
+  `PolyEncoder.point_at_loop.body._native.decide.ax_1`: pre-existing generated certificates
+  that two fixed panic-message strings fit in `U32`.
+
+The bridge adds no proof placeholders or uses of `native_decide`.
+
+To recheck the closure, save the following as `/tmp/ErasureCodeAxioms.lean` and run
+`lake env lean /tmp/ErasureCodeAxioms.lean` from the repository root:
+
+```lean
+import Protocols
+
+#print axioms Protocols.ErasureCode.concreteSpqrErasureCode_correct
+#print axioms Protocols.ErasureCode.encode_toModel
+#print axioms Protocols.ErasureCode.decode_toModel
+#print axioms Protocols.ErasureCode.decoded_message_spec_short
+#print axioms Protocols.ErasureCode.decoded_message_spec_complete
+#print axioms spqr.encoding.polynomial.PolyEncoder.chunk_at_spec_points
+```
+
+## Model provenance
+
+The five files under `Model/` are non-canonical copies from
+`Beneficial-AI-Foundation/secure-messaging` at commit `2144e35`. Their only local differences
+are the provenance header and imports rewritten to the `Protocols.ErasureCode.Model` namespace.
+The canonical files remain in `secure-messaging`.
+
+To recheck a vendored file, run this in a checkout of `secure-messaging` and compare the output
+with the corresponding file under `Protocols/ErasureCode/Model/`, allowing only those two
+mechanical differences:
+
+```sh
+git show 2144e35:SecureMessaging/ErasureCode/<path>
+```

--- a/Protocols/ErasureCode/README.md
+++ b/Protocols/ErasureCode/README.md
@@ -1,13 +1,89 @@
 # SPQR erasure-code verification
 
-This directory connects the extracted SPQR polynomial encoder and decoder to a Reed–Solomon model
-in Lean. The final theorem, [`concreteSpqrErasureCode_correct`](Correct.lean), applies when
-`k ∈ {1, 3, 5, 30, 34, 36}`. For honest chunks at distinct indices, it proves that:
+In Signal, the public keys and ciphertexts used for post-quantum key agreement are large. To keep
+each chat message small, SPQR sends this data in chunks alongside the conversation. Sometimes
+some of the chunks do not get to the other end. Nonetheless, we should be able to recover the
+whole message once we have enough chunks, without waiting for the particular ones we missed.
+[Signal's SPQR post](https://signal.org/blog/spqr/) explains this choice. Here, "message" means
+the data we are encoding, such as a public key or a key-agreement ciphertext.
+
+Erasure codes make this possible by adding redundancy: we can produce extra chunks that let us
+recover the data even if some chunks are lost. The Reed–Solomon code used here does this through
+polynomial interpolation. A line is determined by any two points on it with different x-values.
+Likewise, a polynomial of degree less than `k` is determined by its values at any `k` distinct
+points. We encode the data as values of a polynomial, send evaluations at different points, and
+recover the polynomial once enough arrive. We can then read the original data back from it.
+The implementation does this for sixteen polynomials in parallel, packing their evaluations
+into each chunk.
+
+## Mapping this to the code
+
+The [Rust encoder and decoder](../../src/encoding/polynomial.rs) are translated into Lean by
+Aeneas. `concreteSpqrErasureCode` fills its `encode` and `decode` fields with two wrappers:
+
+- `encodeConcrete` converts the message into bytes, calls `encode_bytes` to prepare the encoder,
+  then calls `chunk_at` for a chosen index and reads the returned bytes as a model chunk.
+- `decodeConcrete` calls `new` to start an empty decoder, calls `add_chunk` for each received
+  chunk, then calls `decoded_message` and reads its result as a model message.
+
+The final `decoded_message` step is opaque in the translation, so its behavior is still assumed,
+as described below.
+
+Correctness means that, given enough chunks, decoding recovers exactly the message we encoded.
+Here, `k` is the number of 32-byte chunks in the original message, before adding redundancy.
+Under the [assumptions below](#assumptions-and-trust), the final theorem,
+[`concreteSpqrErasureCode_correct`](Correct.lean), proves that for unmodified chunks from the
+same message at distinct indices:
 
 - at least `k` chunks recover the original message;
 - fewer than `k` chunks return `none`.
 
-These six values are the point counts supported by the encoder's precomputed polynomial tables.
+The theorem covers `k ∈ {1, 3, 5, 30, 34, 36}`, the six point counts supported by the encoder's
+precomputed polynomial tables. Receiving the same chunk twice does not count as two chunks.
+
+## What we use from functional correctness
+
+The encoder bridge needs two FC results:
+
+- [`encode_bytes_spec`](../../Spqr/Specs/Encoding/Polynomial/PolyEncoder/EncodeBytes.lean)
+  proves that preparing the encoder succeeds and stores the original byte pairs in the right
+  places. For a message of `32 * k` bytes, each of its sixteen stores holds `k` values.
+- [`chunk_at_spec_points`](../../Spqr/Specs/Encoding/Polynomial/PolyEncoder/ChunkAt.lean)
+  starts with those stored values. Under its bounds on store lengths and index arithmetic, it
+  proves that asking for a chunk succeeds, returns the requested index and 32 bytes, and puts the
+  corresponding polynomial evaluation in each byte pair. This covers both reading a stored
+  value and computing an extra chunk by interpolation.
+
+The first result connects the stored values to our message; the second connects those values to
+the chunk we get back. The mathematical lemmas then identify these polynomials with the model's.
+
+On the decoder side, [`new_spec`](../../Spqr/Specs/Encoding/Polynomial/PolyDecoder/New.lean)
+gives us sixteen empty stores, the right number of points needed, and `is_complete = false`.
+In [`Decode.lean`](Correctness/Decode.lean), we prove `add_chunk_decoderInv_spec` directly over
+the translated `add_chunk` loop. For honest chunks at distinct indices, it shows that stored
+points stay sorted, lie on the right polynomials, and reach the required count once enough
+chunks arrive.
+
+That proof reuses smaller FC results: `necessary_points_spec` computes each store's quota,
+`Pt.Insts.CoreCmpOrd.cmp_spec` orders points by their indices, and `GF16.new_value_spec` preserves
+the values read from bytes. It also uses Aeneas' array and iterator results and the sorted-set
+model in [`FunsExternal.lean`](../../SrcTranslated/FunsExternal.lean). The final readout uses the
+two assumed `decoded_message` contracts below.
+
+## How the proof works
+
+1. [`encode_toModel`](Correctness/Encode.lean) proves that the extracted encoder returns the model
+   chunk at each index for the six supported table sizes.
+2. [`decode_toModel`](Correctness/Decode.lean) proves that starting a fresh decoder and adding
+   honest chunks at distinct indices gives the same output as the model decoder.
+3. [`modelEC_correct`](Correctness/Params.lean) proves recovery for the mathematical Reed–Solomon
+   model. Since our encode and decode operations agree with that model, the final theorem gives
+   us the same recovery guarantee for those operations, subject to the stated assumptions.
+
+The decoder equation covers this fresh-decoder fold and its output. It does not equate persistent
+decoder histories produced by different insertion orders, arbitrary input sets, or streaming
+states.
+
 The broader `concreteSpqrErasureCode` constructor packages encode and decode operations for every
 positive `k ≤ 2^16`; `Correct` is a separate property. Its encoder maps extracted construction or
 chunk-lookup failures to `default` so that the operation is total.
@@ -16,19 +92,6 @@ The theorem is the deterministic extensional fragment of Definition A.6 in
 [*How to Compare Bandwidth Constrained Two-Party Secure Messaging Protocols*](https://eprint.iacr.org/2025/2267.pdf).
 Recovery from at least `k` honest chunks strengthens the paper's exactly-`k` clause. The result
 makes no computability, polynomial-time or PPT, asymptotic-cost, or protocol-security claim.
-
-## How the proof works
-
-1. [`encode_toModel`](Correctness/Encode.lean) proves that the extracted encoder returns the model
-   chunk at each index for the six supported table sizes.
-2. [`decode_toModel`](Correctness/Decode.lean) starts a fresh decoder, folds over honest chunks at
-   distinct indices, and proves that its output equals the model decoder's output.
-3. [`modelEC_correct`](Correctness/Params.lean) supplies the Reed–Solomon result. The final theorem
-   rewrites both concrete operations to the model and applies that result.
-
-The decoder equation covers this fresh-decoder fold and its output. It does not equate persistent
-decoder histories produced by different insertion orders, arbitrary input sets, or streaming
-states.
 
 ## Assumptions and trust
 

--- a/Protocols/ErasureCode/README.md
+++ b/Protocols/ErasureCode/README.md
@@ -1,79 +1,85 @@
 # SPQR erasure-code verification
 
-## What is proved
+This directory connects the extracted SPQR polynomial encoder and decoder to a Reed–Solomon model
+in Lean. The final theorem, [`concreteSpqrErasureCode_correct`](Correct.lean), applies when
+`k ∈ {1, 3, 5, 30, 34, 36}`. For honest chunks at distinct indices, it proves that:
 
-`concreteSpqrErasureCode_correct` connects the extracted SPQR encoder and decoder to the
-Reed–Solomon model in this directory. For an allowed message size `k`, an honest set of encoded
-chunks at distinct positions decodes to the original message when it contains at least `k`
-chunks, and decoding returns `none` when it contains fewer than `k` chunks.
+- at least `k` chunks recover the original message;
+- fewer than `k` chunks return `none`.
 
-The proof is split at two correspondence lemmas:
+These six values are the point counts supported by the encoder's precomputed polynomial tables.
+The broader `concreteSpqrErasureCode` constructor packages encode and decode operations for every
+positive `k ≤ 2^16`; `Correct` is a separate property. Its encoder maps extracted construction or
+chunk-lookup failures to `default` so that the operation is total.
 
-- `encode_toModel` shows that the extracted encoder produces the model's chunk at each index.
-- `decode_toModel` shows that the extracted decoder agrees with the model on honest chunk sets.
+The theorem is the deterministic extensional fragment of Definition A.6 in
+[*How to Compare Bandwidth Constrained Two-Party Secure Messaging Protocols*](https://eprint.iacr.org/2025/2267.pdf).
+Recovery from at least `k` honest chunks strengthens the paper's exactly-`k` clause. The result
+makes no computability, polynomial-time or PPT, asymptotic-cost, or protocol-security claim.
 
-This is a functional-correctness result. It does not claim security, cover streaming decode, or
-define an `ErasureCodePayload` instance.
+## How the proof works
 
-The theorem requires `k ∈ {1, 3, 5, 30, 34, 36}`. These are the point counts supported by the
-precomputed polynomial tables used by the Rust implementation; a theorem for arbitrary `k`
-would not describe the shipped code.
+1. [`encode_toModel`](Correctness/Encode.lean) proves that the extracted encoder returns the model
+   chunk at each index for the six supported table sizes.
+2. [`decode_toModel`](Correctness/Decode.lean) starts a fresh decoder, folds over honest chunks at
+   distinct indices, and proves that its output equals the model decoder's output.
+3. [`modelEC_correct`](Correctness/Params.lean) supplies the Reed–Solomon result. The final theorem
+   rewrites both concrete operations to the model and applies that result.
 
-## Assumptions and axiom closure
+The decoder equation covers this fresh-decoder fold and its output. It does not equate persistent
+decoder histories produced by different insertion orders, arbitrary input sets, or streaming
+states.
 
-Rust's `decoded_message` function is deliberately opaque to extraction; see
-[issue #103](https://github.com/Beneficial-AI-Foundation/SparsePostQuantumRatchet-verify/issues/103).
-`Contract.lean` therefore states two assumptions about that real function:
+## Assumptions and trust
 
-- `decoded_message_spec_short`: if any one of the 16 point stores is short, decoding returns
-  `none`.
-- `decoded_message_spec_complete`: complete, sorted stores containing points on suitably
-  low-degree polynomials decode to the bytes of those polynomial evaluations.
+The extracted `decoded_message` function is opaque. [`Contract.lean`](Contract.lean) states two
+assumptions about it and gives their exact hypotheses:
 
-The checked closure of `concreteSpqrErasureCode_correct` contains:
+- `decoded_message_spec_short` says that decoding returns `none` when any one of the sixteen stores
+  is below its quota. It needs no flag premise.
+- `decoded_message_spec_complete` starts with `is_complete = false`. Strictly sorted stores must
+  contain enough points on the stated degree-bounded polynomials; decoding then serializes the
+  requested evaluations.
 
-- `propext`, `Classical.choice`, and `Quot.sound`: Lean's standard logical axioms;
-- `decoded_message_spec_short` and `decoded_message_spec_complete`: the two assumptions above;
-- `encoding.polynomial.PolyDecoder.Insts.SpqrEncodingDecoder.decoded_message`: the extraction
-  opaque;
-- <code>sorr&#121;Ax</code>: inherited through the pre-existing named assumption
-  `Spqr.Aeneas.collect_default_bridge`. Aeneas currently mistranslates the relevant mapped
-  iterator ([aeneas#1043](https://github.com/AeneasVerif/aeneas/issues/1043)); project
-  [issue #409](https://github.com/Beneficial-AI-Foundation/SparsePostQuantumRatchet-verify/issues/409)
-  tracks removing this assumption;
-- `Aeneas.Std.core.fmt.Formatter` and the two `RangeFull.get_unchecked` declarations: opaque
-  primitives in the extracted support library;
-- `PolyEncoder.chunk_at._native.decide.ax_1` and
-  `PolyEncoder.point_at_loop.body._native.decide.ax_1`: pre-existing generated certificates
-  that two fixed panic-message strings fit in `U32`.
+The terminal theorem's checked closure contains:
 
-The bridge adds no proof placeholders or uses of `native_decide`.
+- Lean's standard logical axioms: `propext`, `Classical.choice`, and `Quot.sound`;
+- the two decoder contracts and the opaque `decoded_message` definition;
+- <code>sorr&#121;Ax</code> from two direct origins: the admitted generated map-iterator `next` in
+  [`SrcTranslated/Funs.lean`](../../SrcTranslated/Funs.lean), and
+  `Spqr.Aeneas.collect_default_bridge` in
+  [`Spqr/Specs/Aeneas/MapCollectBridge.lean`](../../Spqr/Specs/Aeneas/MapCollectBridge.lean);
+- the opaque backend type `Aeneas.Std.core.fmt.Formatter`, plus the `RangeFull` extraction
+  externals `get_unchecked` and `get_unchecked_mut`;
+- two pre-existing encoder native certificates showing that fixed panic strings fit in `U32`:
+  `PolyEncoder.chunk_at._native.decide.ax_1` and
+  `PolyEncoder.point_at_loop.body._native.decide.ax_1`.
 
-To recheck the closure, save the following as `/tmp/ErasureCodeAxioms.lean` and run
-`lake env lean /tmp/ErasureCodeAxioms.lean` from the repository root:
-
-```lean
-import Protocols
-
-#print axioms Protocols.ErasureCode.concreteSpqrErasureCode_correct
-#print axioms Protocols.ErasureCode.encode_toModel
-#print axioms Protocols.ErasureCode.decode_toModel
-#print axioms Protocols.ErasureCode.decoded_message_spec_short
-#print axioms Protocols.ErasureCode.decoded_message_spec_complete
-#print axioms spqr.encoding.polynomial.PolyEncoder.chunk_at_spec_points
-```
+Both decoder contracts remain assumptions. The bridge adds no proof placeholders or uses of
+`native_decide`, and a green build cannot validate the assumed contracts. `Contract.lean` also
+describes the broader interpolation helper, its machine-size premise, and its helper-only native
+certificate, which is outside the terminal theorem's closure and does not discharge either
+contract.
 
 ## Model provenance
 
-The five files under `Model/` are non-canonical copies from
-`Beneficial-AI-Foundation/secure-messaging` at commit `2144e35`. Their only local differences
-are the provenance header and imports rewritten to the `Protocols.ErasureCode.Model` namespace.
-The canonical files remain in `secure-messaging`.
+The five files under `Model/` are vendored from the canonical
+[`Beneficial-AI-Foundation/secure-messaging`](https://github.com/Beneficial-AI-Foundation/secure-messaging)
+repository at immutable commit `2144e3561b3ebf775f973a3c2804a0f8edb77f75`:
 
-To recheck a vendored file, run this in a checkout of `secure-messaging` and compare the output
-with the corresponding file under `Protocols/ErasureCode/Model/`, allowing only those two
-mechanical differences:
+- `SecureMessaging/ErasureCode/Defs.lean`
+- `SecureMessaging/ErasureCode/ReedSolomon/Construction.lean`
+- `SecureMessaging/ErasureCode/ReedSolomon/Correctness.lean`
+- `SecureMessaging/ErasureCode/SPQRReedSolomon/Construction.lean`
+- `SecureMessaging/ErasureCode/SPQRReedSolomon/Correctness.lean`
 
-```sh
-git show 2144e35:SecureMessaging/ErasureCode/<path>
-```
+Only these local differences are permitted:
+
+1. The header preserves upstream copyright and authorship, names `LICENSE-APACHE`, and records the
+   provenance, local adaptation credit, full commit, upstream path, and this README.
+2. Imports replace the `SecureMessaging.ErasureCode.*` prefix with
+   `Protocols.ErasureCode.Model.*`.
+
+Apart from that import rewrite, every byte from the first import onward matches the pinned source,
+including body prose and navigation names. A retained `SecureMessaging.ErasureCode.*` name refers
+to the upstream module; its local copy uses the `Protocols.ErasureCode.Model.*` prefix.

--- a/Spqr.lean
+++ b/Spqr.lean
@@ -11,6 +11,7 @@ import Spqr.Crypto.RFC5869
 import Spqr.Lint.Basic
 import Spqr.Lint.SpecIndent
 import Spqr.Math.Gf16.Basic
+import Spqr.Math.Gf16.Equiv
 import Spqr.Math.Gf16.Field
 import Spqr.Math.Gf16.Irreducible
 import Spqr.Math.Gf2Poly.Basic
@@ -38,6 +39,8 @@ import Spqr.Math.Poly.Lagrange.CompletePoints
 import Spqr.Math.Poly.Lagrange.CondProdLinearFactors
 import Spqr.Math.Poly.Lagrange.CountNonSkip
 import Spqr.Math.Poly.Lagrange.DenomProd
+import Spqr.Math.Poly.Lagrange.EvalAtNode
+import Spqr.Math.Poly.Lagrange.Interpolant
 import Spqr.Math.Poly.Lagrange.InterpolantSum
 import Spqr.Math.Poly.LinearFactors.Basic
 import Spqr.Math.Poly.LinearFactors.Degree

--- a/Spqr/Math/Gf16/Equiv.lean
+++ b/Spqr/Math/Gf16/Equiv.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Alessandro D'Angelo
+-/
+import Spqr.Math.Gf16.Field
+import Spqr.Math.Poly.CharTwo.ToGF216
+import Spqr.Math.Gf2Poly.Basic
+import Mathlib.Data.Fintype.EquivFin
+
+/-!
+# Equivalences for `GF216`
+
+This file relates elements of `GF216` to their natural-number representatives.
+-/
+
+open spqr.encoding.polynomial spqr.math.gf
+
+/-- Naturals below `2 ^ 16` have distinct images in `GF216`. -/
+theorem Nat.toGF216_injOn : Set.InjOn Nat.toGF216 (Set.Iio (2 ^ 16)) := by
+  intro a ha b hb hab
+  apply Nat.xor_eq_zero_iff.mp
+  apply Nat_toGF216_eq_zero (Nat.bitwise_lt_two_pow ha hb)
+  calc
+    Nat.toGF216 (a ^^^ b) = Nat.toGF216 a + Nat.toGF216 b := by
+      simp only [Nat.toGF216, natToBinaryPoly_xor, map_add]
+    _ = Nat.toGF216 b + Nat.toGF216 b := by rw [hab]
+    _ = 0 := CharTwo.add_self_eq_zero (Nat.toGF216 b)
+
+/-- The finite type structure on `GF216`. -/
+noncomputable instance GF216.instFintype : Fintype GF216 := Fintype.ofFinite GF216
+
+/-- `GF216` has `2 ^ 16` elements. -/
+theorem GF216.card_eq : Fintype.card GF216 = 2 ^ 16 := by
+  rw [Fintype.card_eq_nat_card]
+  exact GaloisField.card 2 16 (by norm_num)
+
+private noncomputable def GF216.finEquiv : Fin (2 ^ 16) ≃ GF216 :=
+  Equiv.ofBijective (fun n => Nat.toGF216 n.val) <|
+    (Fintype.bijective_iff_injective_and_card _).2 ⟨
+      fun a b h => Fin.ext (Nat.toGF216_injOn a.isLt b.isLt h),
+      by simp only [Fintype.card_fin, GF216.card_eq]⟩
+
+/-- The natural-number representative of an element of `GF216`. -/
+noncomputable def GF216.toNat (x : GF216) : ℕ := (GF216.finEquiv.symm x).val
+
+/-- The natural-number representative of a field element is a 16-bit value. -/
+theorem GF216.toNat_lt (x : GF216) : x.toNat < 2 ^ 16 :=
+  (GF216.finEquiv.symm x).isLt
+
+/-- Converting the natural-number representative back to `GF216` is the identity. -/
+@[simp] theorem GF216.toGF216_toNat (x : GF216) : Nat.toGF216 x.toNat = x := by
+  change GF216.finEquiv (GF216.finEquiv.symm x) = x
+  exact GF216.finEquiv.apply_symm_apply x
+
+/-- Converting an in-range natural through `GF216` is the identity. -/
+@[simp] theorem GF216.toNat_toGF216 {n : ℕ} (h : n < 2 ^ 16) :
+    (Nat.toGF216 n).toNat = n := by
+  change (GF216.finEquiv.symm (GF216.finEquiv ⟨n, h⟩)).val = n
+  rw [GF216.finEquiv.symm_apply_apply]

--- a/Spqr/Math/Poly/Lagrange/EvalAtNode.lean
+++ b/Spqr/Math/Poly/Lagrange/EvalAtNode.lean
@@ -1,0 +1,230 @@
+/-
+Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Alessandro D'Angelo
+-/
+import Spqr.Math.Gf16.Equiv
+import Spqr.Math.Poly.Lagrange.CompletePoints
+
+/-!
+# Evaluation of the scaled Lagrange basis
+
+This file establishes the node values and degree bound for the scaled Lagrange basis.
+-/
+
+open Aeneas Aeneas.Std Polynomial
+open spqr.encoding.gf
+open spqr.encoding.polynomial.PolyConst.lagrange_interpolate_pt_loop
+open spqr.math.gf
+
+namespace spqr.encoding.polynomial
+
+private lemma GF16.toGF216_ne_of_value_ne {a b : GF16} (h : a.value ≠ b.value) :
+    a.toGF216 ≠ b.toGF216 := by
+  intro hab
+  apply h
+  apply UScalar.eq_of_val_eq
+  unfold GF16.toGF216 at hab
+  exact Nat.toGF216_injOn a.value.hBounds b.value.hBounds hab
+
+private theorem eval_condProdLinearFactors_eq_lagrangeDenomProd
+    (pi : GF16) (pts : List Pt) (start : Nat) :
+    (condProdLinearFactors pi pts start).eval pi.toGF216 =
+      lagrangeDenomProd pi pts start := by
+  by_cases hstart : start < pts.length
+  · by_cases heq : pi.value = (pts[start]).x.value
+    · rw [condProdLinearFactors_skip pi pts start hstart heq,
+          lagrangeDenomProd_skip pi pts start hstart heq]
+      exact eval_condProdLinearFactors_eq_lagrangeDenomProd pi pts (start + 1)
+    · rw [condProdLinearFactors_accum pi pts start hstart heq,
+          lagrangeDenomProd_accum pi pts start hstart heq,
+          eval_mul, eval_sub, eval_X, eval_C,
+          eval_condProdLinearFactors_eq_lagrangeDenomProd]
+      simp only [List.get_eq_getElem]
+  · rw [condProdLinearFactors_ge pi pts start (by omega),
+        lagrangeDenomProd_eq_one_of_le pi pts start (by omega), eval_one]
+termination_by pts.length - start
+decreasing_by all_goals omega
+
+private theorem lagrangeDenomProd_ne_zero
+    (pi : GF16) (pts : List Pt) (start : Nat) :
+    lagrangeDenomProd pi pts start ≠ 0 := by
+  by_cases hstart : start < pts.length
+  · by_cases heq : pi.value = (pts[start]).x.value
+    · rw [lagrangeDenomProd_skip pi pts start hstart heq]
+      exact lagrangeDenomProd_ne_zero pi pts (start + 1)
+    · rw [lagrangeDenomProd_accum pi pts start hstart heq]
+      exact mul_ne_zero (sub_ne_zero.mpr (GF16.toGF216_ne_of_value_ne heq))
+        (lagrangeDenomProd_ne_zero pi pts (start + 1))
+  · rw [lagrangeDenomProd_eq_one_of_le pi pts start (by omega)]
+    exact one_ne_zero
+termination_by pts.length - start
+decreasing_by all_goals omega
+
+private theorem eval_condProdLinearFactors_eq_zero_of_value_ne
+    (pi : GF16) (pts : List Pt) (start m : Nat)
+    (hstart : start ≤ m) (hm : m < pts.length)
+    (hne : pi.value ≠ (pts[m]).x.value) :
+    (condProdLinearFactors pi pts start).eval (pts[m]).x.toGF216 = 0 := by
+  have hstart_lt : start < pts.length := by omega
+  by_cases hsm : start = m
+  · subst m
+    rw [condProdLinearFactors_accum pi pts start hm hne]
+    simp [eval_mul, eval_sub, eval_X, eval_C]
+  · by_cases heq : pi.value = (pts[start]).x.value
+    · rw [condProdLinearFactors_skip pi pts start hstart_lt heq]
+      exact eval_condProdLinearFactors_eq_zero_of_value_ne pi pts (start + 1) m
+        (by omega) hm hne
+    · rw [condProdLinearFactors_accum pi pts start hstart_lt heq, eval_mul,
+          eval_condProdLinearFactors_eq_zero_of_value_ne pi pts (start + 1) m
+            (by omega) hm hne, mul_zero]
+termination_by pts.length - start
+decreasing_by all_goals omega
+
+private theorem natDegree_condProdLinearFactors_le
+    (pi : GF16) (pts : List Pt) (start : Nat) :
+    (condProdLinearFactors pi pts start).natDegree ≤ pts.length - start := by
+  by_cases hstart : start < pts.length
+  · by_cases heq : pi.value = (pts[start]).x.value
+    · rw [condProdLinearFactors_skip pi pts start hstart heq]
+      have := natDegree_condProdLinearFactors_le pi pts (start + 1)
+      omega
+    · rw [condProdLinearFactors_accum pi pts start hstart heq]
+      calc
+        ((X - C ((pts[start]).x.toGF216)) *
+            condProdLinearFactors pi pts (start + 1)).natDegree
+            ≤ (X - C ((pts[start]).x.toGF216) : GF216[X]).natDegree +
+                (condProdLinearFactors pi pts (start + 1)).natDegree :=
+              Polynomial.natDegree_mul_le
+        _ ≤ 1 + (pts.length - (start + 1)) := by
+              gcongr
+              · exact Polynomial.natDegree_X_sub_C _ |>.le
+              · exact natDegree_condProdLinearFactors_le pi pts (start + 1)
+        _ ≤ pts.length - start := by omega
+  · rw [condProdLinearFactors_ge pi pts start (by omega)]
+    simp
+termination_by pts.length - start
+decreasing_by all_goals omega
+
+private theorem natDegree_condProdLinearFactors_lt_of_eq
+    (pi : GF16) (pts : List Pt) (start j : Nat)
+    (hstart : start ≤ j) (hj : j < pts.length)
+    (heqj : pi.value = (pts[j]).x.value) :
+    (condProdLinearFactors pi pts start).natDegree < pts.length - start := by
+  have hstart_lt : start < pts.length := by omega
+  by_cases hsj : start = j
+  · subst j
+    rw [condProdLinearFactors_skip pi pts start hj heqj]
+    have := natDegree_condProdLinearFactors_le pi pts (start + 1)
+    omega
+  · by_cases heq : pi.value = (pts[start]).x.value
+    · rw [condProdLinearFactors_skip pi pts start hstart_lt heq]
+      have := natDegree_condProdLinearFactors_lt_of_eq pi pts (start + 1) j
+        (by omega) hj heqj
+      omega
+    · rw [condProdLinearFactors_accum pi pts start hstart_lt heq]
+      have hrec := natDegree_condProdLinearFactors_lt_of_eq pi pts (start + 1) j
+        (by omega) hj heqj
+      calc
+        ((X - C ((pts[start]).x.toGF216)) *
+            condProdLinearFactors pi pts (start + 1)).natDegree
+            ≤ (X - C ((pts[start]).x.toGF216) : GF216[X]).natDegree +
+                (condProdLinearFactors pi pts (start + 1)).natDegree :=
+              Polynomial.natDegree_mul_le
+        _ ≤ 1 + (condProdLinearFactors pi pts (start + 1)).natDegree := by
+              gcongr
+              exact Polynomial.natDegree_X_sub_C _ |>.le
+        _ < pts.length - start := by omega
+termination_by pts.length - start
+decreasing_by all_goals omega
+
+private lemma eval_condProdLinearFactors_eq_zero_of_value_ne_bang
+    (pi : GF16) (pts : List Pt) (start m : Nat)
+    (hstart : start ≤ m) (hm : m < pts.length)
+    (hne : pi.value ≠ (pts[m]!).x.value) :
+    (condProdLinearFactors pi pts start).eval (pts[m]!).x.toGF216 = 0 := by
+  rw [← List.Inhabited_getElem_eq_getElem! pts m hm] at hne ⊢
+  exact eval_condProdLinearFactors_eq_zero_of_value_ne pi pts start m hstart hm hne
+
+private lemma completePoints_take (N : Usize) :
+    (completePoints N).val.take N.val = (completePoints N).val := by
+  apply List.take_of_length_le
+  exact (completePoints N).property.le
+
+private lemma completePoints_x_value {N : Usize} (hN : N.val ≤ 2 ^ 16)
+    {i : Nat} (hi : i < N.val) :
+    ((completePoints N).val[i]!).x.value.val = i := by
+  simp only [global_simps]
+  rw [← List.Inhabited_getElem_eq_getElem! _ i (by simp [hi])]
+  simp only [List.getElem_map, List.getElem_finRange]
+  change (BitVec.ofNat 16 i).toNat = i
+  rw [BitVec.toNat_ofNat, Nat.mod_eq_of_lt (lt_of_lt_of_le hi hN)]
+
+private lemma completePoints_x_toGF216 {N : Usize} (hN : N.val ≤ 2 ^ 16)
+    {i : Nat} (hi : i < N.val) :
+    ((completePoints N).val[i]!).x.toGF216 = Nat.toGF216 i := by
+  unfold GF16.toGF216
+  rw [completePoints_x_value hN hi]
+
+private lemma completePoints_y_toGF216 {N : Usize} {i : Nat} (hi : i < N.val) :
+    ((completePoints N).val[i]!).y.toGF216 = 1 := by
+  simp only [global_simps]
+  simp [hi, GF16.toGF216, Nat.toGF216, natToBinaryPoly_one]
+
+theorem scaledLagrangeBasis_eval_node {N : Std.Usize} (hN : N.val ≤ 2 ^ 16)
+    {j m : ℕ} (hj : j < N.val) (hm : m < N.val) :
+    (scaledLagrangeBasis N j).eval (Nat.toGF216 m) = if j = m then 1 else 0 := by
+  classical
+  unfold scaledLagrangeBasis
+  simp only [Array.getElem!_Nat_eq, completePoints_take, eval_mul, eval_C]
+  by_cases hjm : j = m
+  · subst m
+    rw [if_pos rfl]
+    rw [← completePoints_x_toGF216 hN hj,
+        eval_condProdLinearFactors_eq_lagrangeDenomProd,
+        completePoints_y_toGF216 hj, one_mul]
+    let d := lagrangeDenomProd ((completePoints N).val[j]!).x
+      (completePoints N).val 0
+    have hd : d ≠ 0 := lagrangeDenomProd_ne_zero _ _ _
+    calc
+      d ^ (2 ^ 16 - 2) * d = d ^ (2 ^ 16 - 2 + 1) := (pow_succ d _).symm
+      _ = d ^ (2 ^ 16 - 1) :=
+        congrArg (fun n : Nat => d ^ n) (by norm_num)
+      _ = 1 := by
+        simpa only [GF216.card_eq] using FiniteField.pow_card_sub_one_eq_one d hd
+  · rw [if_neg hjm]
+    rw [← completePoints_x_toGF216 hN hm]
+    have hvalue : ((completePoints N).val[j]!).x.value ≠
+        ((completePoints N).val[m]!).x.value := by
+      intro h
+      have := congrArg UScalar.val h
+      rw [completePoints_x_value hN hj, completePoints_x_value hN hm] at this
+      exact hjm this
+    have hm_pts : m < (completePoints N).val.length := by
+      simpa only [(completePoints N).property] using hm
+    rw [eval_condProdLinearFactors_eq_zero_of_value_ne_bang _ _ 0 m (by omega)
+      hm_pts hvalue, mul_zero]
+
+theorem scaledLagrangeBasis_degree_lt {N : Std.Usize} {j : ℕ} (hj : j < N.val) :
+    (scaledLagrangeBasis N j).degree < (N.val : WithBot ℕ) := by
+  unfold scaledLagrangeBasis
+  simp only [Array.getElem!_Nat_eq, completePoints_take]
+  have hj_pts : j < (completePoints N).val.length := by
+    simpa only [(completePoints N).property] using hj
+  have hget := List.Inhabited_getElem_eq_getElem! (completePoints N).val j hj_pts
+  have heqj : ((completePoints N).val[j]!).x.value =
+      ((completePoints N).val[j]).x.value := congrArg (fun p => p.x.value) hget.symm
+  have hbasis := natDegree_condProdLinearFactors_lt_of_eq
+    ((completePoints N).val[j]!).x (completePoints N).val 0 j
+    (by omega) hj_pts heqj
+  have hdeg :
+      (C (((completePoints N).val[j]!).y.toGF216 *
+          lagrangeDenomProd ((completePoints N).val[j]!).x
+            (completePoints N).val 0 ^ (2 ^ 16 - 2)) *
+        condProdLinearFactors ((completePoints N).val[j]!).x
+          (completePoints N).val 0).natDegree < N.val :=
+    (Polynomial.natDegree_C_mul_le _ _).trans_lt (by
+      simpa only [(completePoints N).property, Nat.sub_zero] using hbasis)
+  exact Polynomial.degree_le_natDegree.trans_lt (WithBot.coe_lt_coe.mpr hdeg)
+
+end spqr.encoding.polynomial

--- a/Spqr/Math/Poly/Lagrange/Interpolant.lean
+++ b/Spqr/Math/Poly/Lagrange/Interpolant.lean
@@ -1,0 +1,48 @@
+/-
+Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Alessandro D'Angelo
+-/
+import Spqr.Math.Poly.Lagrange.EvalAtNode
+import Mathlib.LinearAlgebra.Lagrange
+
+/-!
+# Scaled Lagrange interpolation
+
+This file identifies the scaled-basis sum with mathlib's Lagrange interpolant.
+-/
+
+open Aeneas Polynomial
+
+namespace spqr.encoding.polynomial
+
+theorem sum_scaledLagrangeBasis_eq_interpolate {N : Std.Usize} (hN : N.val ≤ 2 ^ 16)
+    (y : Fin N.val → GF216) :
+    (∑ k : Fin N.val,
+        Polynomial.C (y k) * scaledLagrangeBasis N k.val)
+      = Lagrange.interpolate Finset.univ
+          (fun m : Fin N.val => Nat.toGF216 m.val) y := by
+  classical
+  have hinj : Function.Injective (fun m : Fin N.val => Nat.toGF216 m.val) := by
+    intro a b hab
+    exact Fin.ext (Nat.toGF216_injOn
+      (lt_of_lt_of_le a.isLt hN) (lt_of_lt_of_le b.isLt hN) hab)
+  refine Lagrange.eq_interpolate_of_eval_eq y hinj.injOn ?_ ?_
+  · refine (Polynomial.degree_sum_le Finset.univ _).trans_lt ?_
+    rw [Finset.card_univ, Fintype.card_fin, Nat.cast_withBot,
+      Finset.sup_lt_iff (WithBot.bot_lt_coe N.val)]
+    intro k hk
+    by_cases hy : y k = 0
+    · simp [hy, WithBot.bot_lt_coe]
+    · rw [Polynomial.degree_C_mul hy]
+      exact scaledLagrangeBasis_degree_lt k.isLt
+  · intro m _
+    simp only [Polynomial.eval_finsetSum, Polynomial.eval_mul, Polynomial.eval_C]
+    rw [Finset.sum_eq_single m]
+    · rw [scaledLagrangeBasis_eval_node hN m.isLt m.isLt, if_pos rfl, mul_one]
+    · intro k hk hkm
+      rw [scaledLagrangeBasis_eval_node hN k.isLt m.isLt,
+        if_neg (fun h => hkm (Fin.ext h)), mul_zero]
+    · simp
+
+end spqr.encoding.polynomial

--- a/Spqr/Specs/Encoding/Polynomial/PolyEncoder/ChunkAt.lean
+++ b/Spqr/Specs/Encoding/Polynomial/PolyEncoder/ChunkAt.lean
@@ -1,12 +1,13 @@
 /-
 Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE-APACHE.
-Authors: Hoang Le Truong
+Authors: Hoang Le Truong, Alessandro D'Angelo
 -/
 import Spqr.Specs.Aeneas.TryFromSliceToArray
 import Spqr.Specs.Aeneas.VecIndexRangeFull
 import Spqr.Specs.Aeneas.ResultExpect
 import Spqr.Specs.Encoding.Polynomial.PolyEncoder.PointAt
+import Spqr.Math.Poly.Lagrange.EvalAtNode
 
 /-! # Spec theorem for `PolyEncoder::chunk_at`: loop body 0
 
@@ -460,5 +461,233 @@ theorem chunk_at_spec
   · split <;> simp_all
     grind
   · simp_all
+
+/-! ## Points-state specialization -/
+
+/-- The scaled-Lagrange interpolant stored in points-state slot `j`. -/
+private noncomputable def pointsPoly (pts : Array Point 16#usize) (j : ℕ) :
+    Polynomial GF216 :=
+  ∑ k ∈ Finset.range (pts[j]!).value.length,
+    C (((pts[j]!).value[k]!).toGF216) *
+      scaledLagrangeBasis (alloc.vec.Vec.len ((pts[j]!).value)) k
+
+private theorem eval_scaledLagrangeSum_at_node
+    (v : alloc.vec.Vec GF16) (idx : U16)
+    (hidx : idx.val < v.length) (hlen : v.length ≤ 2 ^ 16) :
+    (∑ k ∈ Finset.range v.length,
+      C ((v[k]!).toGF216) * scaledLagrangeBasis (alloc.vec.Vec.len v) k).eval
+        idx.val.toGF216 = (v[idx.val]!).toGF216 := by
+  classical
+  have hN : (alloc.vec.Vec.len v).val ≤ 2 ^ 16 := by
+    simpa only [alloc.vec.Vec.len_val] using hlen
+  simp only [Polynomial.eval_finsetSum, Polynomial.eval_mul, Polynomial.eval_C]
+  rw [Finset.sum_eq_single idx.val]
+  · rw [scaledLagrangeBasis_eval_node hN hidx hidx, if_pos rfl, mul_one]
+  · intro k hk hne
+    rw [scaledLagrangeBasis_eval_node hN (Finset.mem_range.mp hk) hidx,
+      if_neg hne, mul_zero]
+  · simp [hidx]
+
+private theorem eval_pointsPoly_at_node
+    (pts : Array Point 16#usize) (j : ℕ) (idx : U16)
+    (hidx : idx.val < (pts[j]!).value.length)
+    (hlen : (pts[j]!).value.length ≤ 2 ^ 16) :
+    (pointsPoly pts j).eval idx.val.toGF216 = ((pts[j]!).value[idx.val]!).toGF216 :=
+  eval_scaledLagrangeSum_at_node (pts[j]!).value idx hidx hlen
+
+@[step]
+private theorem chunk_at_loop_spec_points
+    (iter : core.ops.range.Range Usize)
+    (self : PolyEncoder) (idx : U16) (out : alloc.vec.Vec U8)
+    (pts : Array Point 16#usize)
+    (h_state : self.s = .Points pts)
+    (h_end_le : iter.end.val ≤ 16)
+    (h_start_le : iter.start ≤ iter.end)
+    (h_idx_overflow : idx * 16 + 16 ≤ Usize.max)
+    (h_out_overflow : out.length + 2 * iter.end ≤ Usize.max)
+    (h_admissible : ∀ (j : Nat), j < 16 →
+        let len := (pts[j]!).value.length
+        len = 0 ∨ len = 1 ∨ len = 3 ∨ len = 5 ∨
+        len = 30 ∨ len = 34 ∨ len = 36) :
+    chunk_at_loop iter self idx out ⦃ (result : PolyEncoder × alloc.vec.Vec U8) =>
+      result.2.length = out.length + 2 * (iter.end - iter.start) ∧
+      ∀ (j : Nat), iter.start ≤ j → j < iter.end →
+        Nat.toGF216 (256 * result.2[out.length + 2 * (j - iter.start)]! +
+          result.2[out.length + 2 * (j - iter.start) + 1]!) =
+          (pointsPoly pts j).eval idx.val.toGF216 ⦄ := by
+  unfold chunk_at_loop
+  apply loop.spec_decr_nat
+    (measure := fun (p : core.ops.range.Range Usize × PolyEncoder × alloc.vec.Vec U8) =>
+      p.1.end - p.1.start)
+    (inv := fun (p : core.ops.range.Range Usize × PolyEncoder × alloc.vec.Vec U8) =>
+      p.1.end = iter.end ∧
+      iter.start ≤ p.1.start ∧
+      p.1.start ≤ p.1.end ∧
+      p.2.2.length = out.length + 2 * (p.1.start - iter.start) ∧
+      (∀ (j : Nat), iter.start ≤ j → j < p.1.start →
+        Nat.toGF216 (256 * p.2.2[out.length + 2 * (j - iter.start)]! +
+          p.2.2[out.length + 2 * (j - iter.start) + 1]!) =
+          (pointsPoly pts j).eval idx.val.toGF216) ∧
+      (∀ pts', p.2.1.s = .Points pts' → p.2.1 = self) ∧
+      (∀ polys, p.2.1.s = .Polys polys →
+        (∀ (j : Nat), j < 16 → polys[j]!.toGF216Poly = pointsPoly pts j) ∧
+        ∀ (j : Nat), j < 16 →
+          (polys[j]!).coefficients.length + 1 ≤ Usize.max))
+  · rintro ⟨iter', self', out'⟩
+      ⟨h_end', h_iter_ge, h_start_le', h_out_len', h_value', h_points', h_polys'⟩
+    simp only at h_end' h_iter_ge h_start_le' h_out_len' h_points' ⊢
+    dsimp at h_value' h_polys'
+    have h_end_val : iter'.end.val = iter.end.val := by rw [h_end']
+    have h_pts_eq : ∀ {pts' : Array Point 16#usize},
+        self'.s = .Points pts' → self' = self ∧ pts' = pts := by
+      intro pts' hpts'
+      have hself := h_points' pts' hpts'
+      subst hself
+      rw [h_state] at hpts'
+      cases hpts'
+      exact ⟨rfl, rfl⟩
+    have h_adm' : ∀ pts', self'.s = .Points pts' →
+        ∀ (j : Nat), j < 16 →
+          let len := (pts'[j]!).value.length
+          len = 0 ∨ len = 1 ∨ len = 3 ∨ len = 5 ∨
+          len = 30 ∨ len = 34 ∨ len = 36 := by
+      intro pts' hpts' j hj
+      obtain ⟨-, hpe⟩ := h_pts_eq hpts'
+      subst pts'
+      exact h_admissible j hj
+    have h_coeff' : ∀ polys, self'.s = .Polys polys →
+        ∀ (j : Nat), j < 16 →
+          (polys[j]!).coefficients.length + 1 ≤ Usize.max := by
+      intro polys hpolys j hj
+      exact (h_polys' polys hpolys).2 j hj
+    by_cases h_iter_lt : iter'.start.val < iter'.end.val
+    · have h_body := chunk_at_loop.body_spec idx iter' self' out'
+        (by omega) h_idx_overflow (by grind) h_adm' h_coeff'
+      apply WP.spec_mono h_body
+      intro cf h_cf
+      match cf with
+      | ControlFlow.done (self'', out'') =>
+          simp only [] at h_cf ⊢
+          exact absurd h_iter_lt h_cf.2.2
+      | ControlFlow.cont (iter'', self'', out'') =>
+          simp only [] at h_cf ⊢
+          obtain ⟨h_lt, h_start1, h_end1, g, hi, lo, h_out_eq, h_encode,
+            h_idx1, h_match⟩ := h_cf
+          -- one state analysis yields the emitted value and both state-preservation clauses
+          have h_step :
+              g.toGF216 = (pointsPoly pts iter'.start.val).eval idx.val.toGF216 ∧
+              (∀ pts', self''.s = .Points pts' → self'' = self) ∧
+              (∀ polys, self''.s = .Polys polys →
+                (∀ (j : Nat), j < 16 → polys[j]!.toGF216Poly = pointsPoly pts j) ∧
+                ∀ (j : Nat), j < 16 →
+                  (polys[j]!).coefficients.length + 1 ≤ Usize.max) := by
+            cases h_s : self'.s with
+            | Points pts_curr =>
+                obtain ⟨hself, hpe⟩ := h_pts_eq h_s
+                subst self' pts_curr
+                simp only [h_state] at h_match
+                by_cases h_cache : idx < (pts[iter'.start]!).value.length
+                · simp only [if_pos h_cache] at h_match
+                  refine ⟨?_, fun _ _ => h_match.2, fun polys hpolys => ?_⟩
+                  · rw [h_match.1]
+                    exact (eval_pointsPoly_at_node pts iter'.start.val idx h_cache (by
+                      have hlen := h_admissible iter'.start.val (by omega)
+                      dsimp only at hlen
+                      omega)).symm
+                  · rw [h_match.2] at hpolys
+                    simp [h_state] at hpolys
+                · simp only [if_neg h_cache] at h_match
+                  refine ⟨?_, fun pts' h' => ?_, fun polys hpolys => ?_⟩
+                  · cases h_new : self''.s with
+                    | Points pts_new => simp [h_new] at h_match
+                    | Polys polys_new =>
+                        simp only [h_new] at h_match
+                        rw [h_match.1 iter'.start.val (by omega)] at h_match
+                        exact h_match.2.2
+                  · simp [h'] at h_match
+                  · simp only [hpolys] at h_match
+                    exact ⟨h_match.1, h_match.2.1⟩
+            | Polys polys_curr =>
+                simp only [h_s] at h_match
+                have hpoly := (h_polys' polys_curr h_s).1 iter'.start.val (by omega)
+                rw [hpoly] at h_match
+                refine ⟨h_match.1, fun pts' h' => ?_, fun polys hpolys => ?_⟩
+                · rw [h_match.2] at h'
+                  simp [h_s] at h'
+                · rw [h_match.2] at hpolys
+                  exact h_polys' polys hpolys
+          constructor
+          · refine ⟨by rw [h_end1]; exact h_end', by grind, by grind, ?_, ?_,
+              h_step.2.1, h_step.2.2⟩
+            · change out''.val.length = out.val.length +
+                  2 * (iter''.start.val - iter.start.val)
+              rw [h_out_eq]
+              simp [h_out_len', h_start1]
+              grind
+            · intro j hj1 hj2
+              by_cases hj_lt : j < iter'.start.val
+              · have h_old := h_value' j hj1 hj_lt
+                grind
+              · have hj_eq : j = iter'.start.val := by omega
+                subst hj_eq
+                have h_pair :
+                    256 * out''[out.length + 2 * (iter'.start.val - iter.start)]! +
+                      out''[out.length + 2 * (iter'.start.val - iter.start) + 1]! =
+                        g.value.val := by
+                  grind
+                rw [h_pair]
+                simpa only [GF16.toGF216] using h_step.1
+          · grind
+    · unfold chunk_at_loop.body
+      obtain ⟨⟨opt, iter1'⟩, hnext, h_none, h_some⟩ :=
+        WP.spec_imp_exists (core.iter.range.IteratorRange.next_Usize_spec' iter')
+      rw [hnext]
+      simp only [bind_tc_ok]
+      obtain ⟨h_opt_eq, _⟩ := h_none h_iter_lt
+      subst h_opt_eq
+      dsimp
+      refine ⟨?_, fun j hj1 hj2 => h_value' j hj1 (by grind)⟩
+      simp [h_out_len']
+      grind
+  · dsimp
+    refine ⟨rfl, le_refl _, h_start_le, ?_, ?_, ?_, ?_⟩
+    · simp
+    · intro j hj1 hj2
+      omega
+    · intro pts' hpts'
+      rfl
+    · intro polys hpolys
+      have h := h_state.symm.trans hpolys
+      cases h
+
+@[step]
+theorem chunk_at_spec_points
+    (self : encoding.polynomial.PolyEncoder) (idx : Std.U16)
+    (pts : Array Point 16#usize)
+    (h_state : self.s = .Points pts)
+    (h_idx_overflow : idx.val * 16 + 16 ≤ Usize.max)
+    (h_admissible : ∀ (j : Nat), j < 16 →
+        let len := (pts[j]!).value.length
+        len = 0 ∨ len = 1 ∨ len = 3 ∨ len = 5 ∨
+        len = 30 ∨ len = 34 ∨ len = 36) :
+    chunk_at self idx ⦃ ((chunk, _self') :
+        encoding.Chunk × encoding.polynomial.PolyEncoder) =>
+      chunk.index = idx ∧
+      chunk.data.val.length = 32 ∧
+      ∀ (j : Nat), j < 16 →
+        Nat.toGF216 (256 * chunk.data.val[2 * j]! + chunk.data.val[2 * j + 1]!) =
+          (∑ k ∈ Finset.range (pts[j]!).value.length,
+            Polynomial.C (((pts[j]!).value[k]!).toGF216) *
+              scaledLagrangeBasis (alloc.vec.Vec.len ((pts[j]!).value)) k).eval
+            (idx.val.toGF216) ⦄ := by
+  unfold chunk_at
+  step*
+  · simp [alloc.vec.Vec.with_capacity]
+    grind
+  · simp_all [alloc.vec.Vec.with_capacity, alloc.vec.Vec.new,
+      List.length_nil]
+  simp [core.result.Result.expect]
+  split <;> simp_all [pointsPoly]
+  grind
 
 end spqr.encoding.polynomial.PolyEncoder

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,6 +1,6 @@
 name = "Spqr"
 version = "0.1.0"
-defaultTargets = ["Spqr", "SrcTranslated"]
+defaultTargets = ["Spqr", "SrcTranslated", "Protocols"]
 
 [leanOptions]
 autoImplicit = false
@@ -32,6 +32,9 @@ name = "Spqr"
 
 [[lean_lib]]
 name = "Utils"
+
+[[lean_lib]]
+name = "Protocols"
 
 [[lean_exe]]
 name = "status"

--- a/scripts/Audit.lean
+++ b/scripts/Audit.lean
@@ -21,6 +21,7 @@ Section 4 writes `sorry-manifest.txt` (machine-readable, one line per
 Reference: https://lean-lang.org/doc/reference/latest/ValidatingProofs/
 -/
 import Spqr
+import Protocols
 
 open Lean Elab Command
 
@@ -38,7 +39,7 @@ run_cmd liftTermElabM do
   let mut specsModuleNames : Array Name := #[]
   for h : i in [:moduleNames.size] do
     let m := moduleNames[i]
-    if m.getRoot == `Spqr || m.getRoot == `SrcTranslated then
+    if m.getRoot == `Spqr || m.getRoot == `SrcTranslated || m.getRoot == `Protocols then
       projectModuleIdxs := projectModuleIdxs.insert i
       projectModuleNames := projectModuleNames.push m
       if m.toString.startsWith "Spqr.Specs" then
@@ -236,6 +237,9 @@ run_cmd liftTermElabM do
   if projTrust then logInfo m!"⚠  `Lean.trustCompiler` found in project."
   else logInfo m!"✓  No `Lean.trustCompiler` in project."
   logInfo m!"\nTotal custom axioms: {projAllCustom.size}"
+  logInfo m!"\n--- Protocols custom axioms ---"
+  for a in projAllCustom.toArray do
+    if a.getRoot == `Protocols then logInfo m!"  • {a}"
 
   -- ── SECTION 4: Machine-readable sorry manifest ──────────────────────────
 


### PR DESCRIPTION
This PR adds a `Protocols` library and proves that the extracted SPQR erasure code, wrapped as an `ErasureCode`, is correct in the model's sense: `concreteSpqrErasureCode_correct` in `Protocols/ErasureCode/Correct.lean`. For a message of `k` chunks, decoding any `k` of its encoded chunks (distinct indices, any order) returns the message, and decoding fewer returns `none`.

The proof goes through the secure-messaging model instead of reproving Reed-Solomon facts about the code. `Correctness/Params.lean` instantiates the model's `ReedSolomon.Parameters` at the evaluation points the code actually uses (`fun i => Nat.toGF216 i.val`), so the model's proven correctness theorem covers that instance with no new proof. `Correctness/Encode.lean` and `Correctness/Decode.lean` prove the agreement lemmas `encode_toModel` and `decode_toModel`: the wrapped extracted functions agree with the model instance (decode agreement is stated on honest chunk sets, where it is true; it is false for arbitrary sets, since the code dedups duplicate indices while the model rejects them). `Correct.lean` derives the theorem by rewriting along these two lemmas. The `_toModel` suffix is intended as a convention, playing the role `_spec` plays for function-level verification: it marks where extracted code is tied to a hand-written model.

`Protocols/ErasureCode/Model/` is vendored verbatim from secure-messaging at commit `2144e35` (in-repo imports rewritten, provenance header added, nothing else); the canonical copy stays upstream. Vendoring rather than a lake `require` because the toolchains have diverged: this repo follows the Aeneas nightlies (Lean v4.31.0), secure-messaging is on v4.32.0. `Model/` remains separate from `Correctness/` so the vendored copy can be removed cleanly after the toolchain version bump.

Outside `Protocols/`: `Spqr/Math/Gf16/Equiv.lean` (inverse of `Nat.toGF216` below `2^16`), `Spqr/Math/Poly/Lagrange/{EvalAtNode,Interpolant}.lean` (the transpiled Lagrange basis evaluates to the Kronecker delta at the nodes, and its interpolant equals mathlib's `Lagrange.interpolate`), and one theorem appended to `Spqr/Specs/Encoding/Polynomial/PolyEncoder/ChunkAt.lean` (`chunk_at_spec_points`, giving chunk bytes semantics when the encoder is still in the `Points` state). `lakefile.toml` gains the `Protocols` lib and `scripts/Audit.lean` now scans it.

What is assumed: `decoded_message` was deliberately left unextracted (#103), so `Protocols/ErasureCode/Contract.lean` states two named axioms about it, one for the incomplete case (`none`) and one for the complete case (the serialized evaluations). These cannot fail a build, so they deserve the most review attention: check both statements against `src/encoding/polynomial.rs` lines 906-963, in both directions (too weak breaks the bridge, too strong would be unsatisfiable in reality). The axiom closure of the theorem also contains `sorryAx` through the pre-existing `collect_default_bridge` assumption (#409) and the standard kernel axioms. `Protocols/ErasureCode/README.md` lists the full classified closure and a recheck recipe.

Scope limits: correctness only. `k` is restricted to `{1, 3, 5, 30, 34, 36}`, the per-polynomial point counts with precomputed basis tables in the Rust; other values panic in debug builds, so a general statement would be false of the code. The four production sizes (3, 5, 30, 36) are covered. Streaming decode and the payload layer are out of scope.

Suggested review order: `Protocols/ErasureCode/README.md`, then `Contract.lean` against the Rust, then the statement of `concreteSpqrErasureCode_correct`, then the two `_toModel` lemmas; everything else supports those.

**N.B.:** The PR is split in three commits; first is infra, the second is just a trick to avoid version bumping on spqr-verify (since secure-messaging is now using Lean 4.32; the third commit (1200ish LOC) is the most relevant one for the bridge.

