### PR TITLE
Specify and verify `serialize::Error` `Debug::fmt` and `Display::fmt` in `serialize.rs`

### DIFF
--- a/Spqr.lean
+++ b/Spqr.lean
@@ -197,6 +197,8 @@ import Spqr.Specs.Lib.Version.TryFrom
 import Spqr.Specs.Lib.Version.U8.From
 import Spqr.Specs.Proto.PqRatchet.Version.TryFrom
 import Spqr.Specs.Serialize.Error.Clone
+import Spqr.Specs.Serialize.Error.Debug
+import Spqr.Specs.Serialize.Error.Display
 import Spqr.Specs.Serialize.Error.Eq
 import Spqr.Specs.Serialize.Error.From
 import Spqr.Specs.Util.Compare

--- a/Spqr/Specs/Serialize/Error/Debug.lean
+++ b/Spqr/Specs/Serialize/Error/Debug.lean
@@ -1,0 +1,47 @@
+/-
+Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Liao Zhang
+-/
+import SrcTranslated.Funs
+
+/-! # Spec theorem for
+`spqr::serialize::{impl core::fmt::Debug for spqr::serialize::Error}::fmt`
+
+The derived `Debug` for the fieldless enum `serialize::Error` dispatches on the
+constructor and writes the variant name with `Formatter::write_str`:
+
+- `Deserialization` → `"Deserialization"`
+- `EncodingDecoding` → `"EncodingDecoding"`
+
+Under the Aeneas `core::fmt` model `write_str` always returns `(.Ok (), f)`, so
+formatting always succeeds and preserves the formatter state.
+
+**Source**: src/serialize.rs (line 6, `#[derive(Debug, ...)]`)
+-/
+
+open Aeneas Aeneas.Std Result
+
+namespace spqr.serialize.Error.Insts.CoreFmtDebug
+
+/-- **Spec theorem for `serialize.Error.Insts.CoreFmtDebug.fmt`**:
+
+The derived `Debug for Error` always succeeds (no panic) for any variant `self` and any
+formatter `f`. It returns `Ok(())` and leaves the formatter unchanged (under the current
+Aeneas model of the `core::fmt` machinery):
+
+  `result.1 = .Ok ()  ∧  result.2 = f` -/
+@[step]
+theorem fmt_spec (self : serialize.Error) (f : core.fmt.Formatter) :
+    fmt self f ⦃ (result : (core.result.Result Unit core.fmt.Error) × core.fmt.Formatter) =>
+      result.1 = .Ok () ∧ result.2 = f ⦄ := by
+  unfold fmt
+  match self with
+  | .Deserialization =>
+    simp only [core.fmt.Formatter.write_str]
+    step*
+  | .EncodingDecoding =>
+    simp only [core.fmt.Formatter.write_str]
+    step*
+
+end spqr.serialize.Error.Insts.CoreFmtDebug

--- a/Spqr/Specs/Serialize/Error/Display.lean
+++ b/Spqr/Specs/Serialize/Error/Display.lean
@@ -1,0 +1,47 @@
+/-
+Copyright (c) 2026 The Beneficial AI Foundation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE-APACHE.
+Authors: Liao Zhang
+-/
+import SrcTranslated.Funs
+
+/-! # Spec theorem for
+`spqr::serialize::{impl core::fmt::Display for spqr::serialize::Error}::fmt`
+
+The `thiserror`-derived `Display` for the fieldless enum `serialize::Error` dispatches on
+the constructor and writes the `#[error("...")]` message with `Formatter::write_str`:
+
+- `Deserialization` → `"General deserialization error"`
+- `EncodingDecoding` → `"Error with encoder/decoder serialization"`
+
+Under the Aeneas `core::fmt` model `write_str` always returns `(.Ok (), f)`, so
+formatting always succeeds and preserves the formatter state.
+
+**Source**: src/serialize.rs (lines 6-12, `#[derive(thiserror::Error)]` + `#[error(...)]`)
+-/
+
+open Aeneas Aeneas.Std Result
+
+namespace spqr.serialize.Error.Insts.CoreFmtDisplay
+
+/-- **Spec theorem for `serialize.Error.Insts.CoreFmtDisplay.fmt`**:
+
+The `Display for Error` implementation always succeeds (no panic) for any variant `self`
+and any formatter `f`. It returns `Ok(())` and leaves the formatter unchanged (under the
+current Aeneas model of the `core::fmt` machinery):
+
+  `result.1 = .Ok ()  ∧  result.2 = f` -/
+@[step]
+theorem fmt_spec (self : serialize.Error) (f : core.fmt.Formatter) :
+    fmt self f ⦃ (result : (core.result.Result Unit core.fmt.Error) × core.fmt.Formatter) =>
+      result.1 = .Ok () ∧ result.2 = f ⦄ := by
+  unfold fmt
+  match self with
+  | .Deserialization =>
+    simp only [core.fmt.Formatter.write_str]
+    step*
+  | .EncodingDecoding =>
+    simp only [core.fmt.Formatter.write_str]
+    step*
+
+end spqr.serialize.Error.Insts.CoreFmtDisplay


### PR DESCRIPTION
This PR specifies and verifies `spqr::serialize::{impl core::fmt::Debug for spqr::serialize::Error}::fmt` and `spqr::serialize::{impl core::fmt::Display for spqr::serialize::Error}::fmt` in `serialize.rs`.

Both are two-branch dispatches on the fieldless enum calling `Formatter::write_str`. Spec: `result.1 = .Ok () ∧ result.2 = f`, same shape and proof as `Spqr/Specs/Lib/SecretOutput/Fmt.lean`.

New files:
- `Spqr/Specs/Serialize/Error/Debug.lean`
- `Spqr/Specs/Serialize/Error/Display.lean`

closes #294
closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)